### PR TITLE
Add missing ofMain includes

### DIFF
--- a/src/ofxSpout/Receiver.cpp
+++ b/src/ofxSpout/Receiver.cpp
@@ -1,6 +1,7 @@
 #include "Receiver.h"
 #include "ofGraphics.h"
 #include "Utils.h"
+#include "ofMain.h"
 
 namespace ofxSpout {
 	//----------

--- a/src/ofxSpout/Sender.cpp
+++ b/src/ofxSpout/Sender.cpp
@@ -1,6 +1,7 @@
 #include "Sender.h"
 
 #include "ofFbo.h"
+#include "ofMain.h"
 
 namespace ofxSpout {
 	//----------


### PR DESCRIPTION
It is needed for ofLogError. If the caller code does not include ofMain itself, it doesn't build.