### PR TITLE
Fix Possibly Missing Library Files Causing Build Failure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-libs/
 docs/
 
 *.depend

--- a/libs/SpoutSDK/src/Spout.cpp
+++ b/libs/SpoutSDK/src/Spout.cpp
@@ -1,0 +1,2887 @@
+﻿//
+//		Spout SDK
+//
+//		Spout.cpp
+//
+// Documentation <https://spoutgl-site.netlify.app>	
+//
+// ====================================================================================
+//		Revisions :
+//
+//		14-07-14	- SelectSenderPanel - return true was missing.
+//		16-07-14	- deleted fbo & texture in SpoutCleanup - test for OpenGL context
+//					- used CopyMemory in FlipVertical instead of memcpy
+//					- cleanup
+//		18-07-14	- removed SpoutSDK local fbo and texture - used in the interop class now
+//		22-07-14	- added option for DX9 or DX11
+//		25-07-14	- Malcolm Bechard mods to header to enable compilation as a dll
+//					- ReceiveTexture - release receiver if the sender no longer exists
+//					- ReceiveImage same change - to be tested
+//		27-07-14	- CreateReceiver - bUseActive flag instead of null name
+//		31-07-14	- Corrected DrawTexture aspect argument
+//		01-08-14	- TODO - work on OpenReceiver for memoryshare
+//		03-08-14	- CheckSpoutPanel allow for unregistered sender
+//		04-08-14	- revise CheckSpoutPanel
+//		05-08-14	- default true for setverticalsync in sender and receiver classes
+//		11-08-14	- fixed incorrect name arg in OpenReceiver for ReceiveTexture / ReceiveImage
+//					2.004 release 19-08-14
+//		24-08-14	- changed back to WM_PAINT message instead of RedrawWindow due to FFGL receiver bug appearing again
+//		27-08-14	- removed texture init check from SelectSenderPanel
+//		29-08-14	- changed SelectSenderPanel to use revised SpoutPanel with user message support
+//		03.09.14	- cleanup
+//		15.09.14	- protect against null string copy in SelectSenderPanel
+//		22.09.14	- checking of bUseAspect function in CreateReceiver
+//		23.09.14	- test for DirectX 11 support in SetDX9 and GetDX9
+//		24.09.14	- updated project file for DLL to include SpoutShareMemory class
+//		28.09.14	- Added GL format for SendImage and FlipVertical
+//					- Added bAlignment  (4 byte alignment) flag for SendImage
+//					- Added Host FBO for SendTexture, DrawToSharedTexture
+//					- Added Host FBO for ReceiveTexture
+//		11.10.14	- Corrected UpdateSender to recreate sender using CreateInterop
+//					- Corrected SelectSenderpanel so that an un-initialized string is not used
+//		12.10.14	- Included SpoutPanel always bring to topmost in SelectSenderPanel
+//					- allowed for change of sender size in DrawToSharedTexture
+//		15.10.14	- added debugging aid for texture access locks
+//		29.10.14	- changes to SendImage
+//		23.12.14	- added host fbo arg to ReceiveImage
+//		30.01.15	- Read SpoutPanel path from registry (dependent on revised installer)
+//					  Next path checked is module path, then current working directory
+//		06.02.15	- added #pragma comment(lib,.. for "Shell32.lib" and "Advapi32.lib"
+//		10.02.15	- added Optimus NvOptimusEnablement export to Spout.h - should apply to all apps including this SDK.
+//		22.02.15	- added FindFileVersion for future use
+//		24.05.15	- Registry read of sender name for CheckSpoutPanel (see SpoutPanel)
+//		29.05.15	- Included SetAdapter for multiple adapters - Franz Hildgen.
+//		01.06.15	- Read/Write DX9 mode from registry
+//		02.06.15	- Added GetAdapter, GetNumAdapters, GetAdapterName
+//		04.07.15	- corrected "const char *" arg for GetSenderInfo
+//		08.07.15	- Recompile for global DX9 flag
+// 		01.08.15	- OpenReceiver - safety in case no opengl context
+//		22.08.15	- Change to CheckSpoutPanel to wait for SpoutPanel mutex to open and then close
+//		24.08.15	- Added GetHostPath to retrieve the path of the host that produced the sender
+//		01.09.15	- added MessageBox error warnings in InitSender for better user diagnostics
+//					  also added MessageBox warnings in SpoutGLDXinterop::CreateInterop
+//		09.09.15	- included g_ShareHandle in CheckSpoutPanel
+//					- removed bGLDXcompatibleShareInitOK becasue there is no single initialization any more
+//		12.09.15	- Incremented application sender name if one already exists with the same name
+//					- Finalised revised SpoutMemoryShare class and functions
+//		15.09.15	- Disable memoryshare if the 2.005 installer has not set the "MemoryShare" key
+//					  to avoid problems with 2.004 apps.
+//					- Change logic of OpenSpout so that fails for incompatible hardware
+//					  if memoryshare is not set. Only 2.005 apps can set memoryshare.\
+//		19.09.15	- Changed GetImageSize to look for NULL sharehandle of a sender to determine
+//					  if it is memoryshare. Used by SpoutCam.
+//		22.09.15	- Fixed memoryshare sender update in UpdateSender
+//		25.09.15	- Changed SetMemoryShareMode for 2.005 - now will only set true for 2.005 and above
+//		09.10.15	- DrawToSharedTexture - invert default false instead of true
+//		10.10.15	- CreateSender - introduced a temporary DX shared texture for 2.005 memoryshare to prevent
+//					  a crash with existing 2.004 apps
+//		22.10.15	- Changed CheckSpoutPanel so that function variables are only created if SpoutPanel has been opened
+//		26.10.15	- Added bIsSending and bIsReceiving for safety release of sender in destructor.
+//		14.11.15	- changed functions to "const char *" where required
+//		18.11.15	- added CheckReceiver so that DrawSharedTexture can be used by a receiver
+//		24.11.15	- changes to CheckSpoutPanel to favour ActiveSender over the Registry sender name (used by VVVV)
+//					- Reintroduced 250msec sleep after SpoutPanel activation
+//		29.11.15	- fixed const char problem in ReadPathFromRegistry
+//		18.01.16	- added CleanSenders before opening a new sender in case of orphaned sender names in the list
+//		10.02.16	- added RemovePathFromRegistry
+//		26.02.16	- recompile for Processing library 2.0.5.2 release
+//		06.03.16	- added GetSpoutSenderName() and IsSpoutInitialized() for access to globals
+//		17.03.16	- removed alignment argument from ReceiveImage
+//					  Check for bgra extensions in receiveimage and sendimage
+//					  Support only for rgba or bgra
+//					  Changed to const unsigned char for Sendimage buffer
+//		21.03.16	- Added glFormat and bInvert to SendImage
+//					- Included LoadGLextensions in InitSender and InitReceiver for memoryshare mode.
+//		24.03.16	- Added HostFBO argument to WriteMemory and ReadMemory function calls.
+//		04.04.16	- Added HostFBO argument to SendImage - only used for texture share
+//					  Merge from Smokhov https://github.com/leadedge/Spout2/pull/14
+//					- Changed default invert flag for SendImage to true.
+//		24.04.16	- Added IsPBOavailable to test for PBO support.
+//		04.05.16	- SetPBOavailable(true/false) added to enable/disable pbo functions
+//		07.05.16	- SetPBOavailable changed to SetBufferMode
+//		18.06.16	- Add invert to ReceiveImage
+//			2.005 release 23-06-16
+//		29.06.16	- Added ReportMemory() for debugging
+//					- Changed OpenSpout to fail for DX9 if no hwnd
+//					  https://github.com/leadedge/Spout2/issues/18
+//		03.07.16	- Fix dwFormat repeat declaration in InitSender
+//		15.01.17	- Add GetShareMode, SetShareMode
+//		18.01.17	- GetImageSize redundant for 2.006
+//		22.01.17	- include zero char in SelectSenderPanel NULL arg checks
+//		25.05.17	- corrected SendImage UpdateSender to use passed width and height
+//			2.006 release 08-02-17
+//
+//		VS2015
+//
+//		02.06.17	- Registry functions moved to SpoutUtils
+//		06.06.17	- Added GLDXavailable to OpenSpout
+//		09.06.17	- removed g_TexID - not used
+//		05.10.17	- https://github.com/leadedge/Spout2/issues/24
+//					- OpenReceiver simplify code
+//					- CheckSpoutPanel simplify code, remove text file sender retrieval
+//					- Add InitReceiver override to include sharehandle and format args
+//		10.03.18	- Noted that change to OpenReceiver for offscreen rendering
+//					  not needed because hwnd can be null for spoutdx.CreateDX9device
+//					  https://github.com/leadedge/Spout2/issues/18
+//
+//		VS2017
+//
+//		23.08.18	- Add SendFboTexture - see changes to WriteGLDXtexture in SpoutGLDXinterop.cpp
+//		17.10.18	- Retrieve global render window handle in OpenSpout
+//		01.11.18	- SendImage bInvert default false to align with SpoutSender.cpp		
+//		01.11.18	- Changes to SelectSenderPanel to terminate SpoutPanel if it has crashed.
+//		03.11.18	- Texture creation patch for compatibility with 2.004 removed for Spout 2.007
+//		13.11.18	- Remove CPU mode
+//		24.11.18	- Remove redundant GetImageSize
+//		27.11.18	- Add RemovePadding for correction of image stride
+//		28.11.18	- Add IsFrameNew and HasNewFrame
+//		14.12.18	- Clean up for SpoutLibrary
+//		15.12.18	- UpdateSender - release and re-create sender to avoid memory leak
+//		17.12.18	- Change Spout dll Project properties to / MT
+//		28.12.18	- Check mutex handle before close in CheckSpoutPanel
+//		28.12.18	- Rebuild Spout.dll 32 / 64bit - Version 2.007
+//		03.01.19	- Changed to revised registry functions in SpoutUtils
+//		04.01.19	- Add OpenGL window creation functions for SpoutLibrary
+//		05.01.19	- Change names for high level receiver functions for SpoutLibrary
+//		16.01.19	- Fix ReceiveTextureData for sender name change
+//		22.01.19	- Remove unsused bIsReceiving flag
+//		05.03.19	- Add log notice for ReleaseSender
+//		05.04.19	- Change GetSenderName to GetSender
+//					  Reserve const char * GetSenderName for receiver class
+//		17.06.19	- Fix missing log warning argument in UpdateSender
+//		26.06.19	- Cleanup changes to UpdateSender
+//		13.01.20	- Removed sleep time for SpoutPanel to open
+//		19.01.20	- Change SendFboTexture to SendFbo
+//		20.01.20	- Corrected SendFbo for width/height < shared texture
+//		21.01.20	- Remove auto sender update in send functions
+//					  Remove debug print from InitSender
+//		25.05.20	- Correct filename case for all #includes throughout
+//		14.07.20	- Removed unused bChangeRequested flag
+//		18.07.20	- Rebuild binaries Win32 and x64 /MT VS2017
+//		04.09.20	- Dynamic switch between memory and texture share modes
+//		05.09.20	- OpenReceiver - Switch to memoryshare if receiver and sender use different GPU
+//					  See SpoutGLDXinterop to set adapter index to "usage" field in sender shared memory
+//		06.09.20	- Do not change share mode flags in SpoutCleanup
+//		07.09.20	- Correct receiver switch from memory to texture if texture compatible
+//		08.09.20	- OpenReceiver - remove warning log for receiver and sender using a different GPU
+//					  InitSender - switch to memoryshare on CreateInterop failure
+//		09.09.20	- SetAdapter - reset and perform compatibility test
+//		15.09.20	- Remove SpoutMessageBox from OpenSpout()
+//					  Failure must be handled by the application
+//		17.09.20	- Change GetMemoryShare(const char* sendername) to
+//					  GetSenderMemoryShare(const char* sendername) for compatibility with SpoutLibrary
+//					  Add GetSenderAdapter
+//		18.09.20	- Add SetSenderAdapter
+//		22.09.20	- OpenReceiver sender/receiver GPU check
+//		23.09.20	- Corrected SetSenderAdapter
+//					  Logic corrections
+//		24.09.20	- Correction of SetSenderAdapter as bool not void
+//		25.09.20	- Remove GetSenderAdapter/SetSenderAdapter - not reliable
+//		17.10.20	- Change SetDX9format from D3D_FORMAT to DWORD
+//		27.12.20	- Multiple changes for SpoutGL base class - see SpoutSDK.cpp
+//					  Remove DX9 support
+//					  CPU backup enhanced using dual DirectX staging textures
+//					  Auto switch to CPU backup if GL/DX incompatible
+//		10.01.21	- SetSenderName - auto increment of sender name if the sender already exists
+//		12.01.21	- Release orphaned senders in SelectSenderPanel
+//					- CheckSender : write host path to the sender shared memory Description field
+//					  in spoutSenderNames::CreateSender
+//		13.01.21	- Release orphaned senders in SpoutPanel.exe instead of SelectSenderPanel
+//					  Additional checks for un-registered senders
+//		18.01.21	- ReceiveSenderData : Check if the name is in the sender list
+//		26.02.21	- Add GetSenderGLDXready() for receiver
+//		01.03.21	- Add SetSenderID
+//		11.03.21	- Rename functions GetSenderCPU and GetSenderGLDX
+//		13.03.21	- memoryshare.CloseSenderMemory() in ReleaseSender
+//		15.03.21	- IsFrameNew - return frame.IsFrameNew()
+//		20.03.21	- memoryshare.CloseSenderMemory() in ReleaseReceiver
+//		02.04.21	- Add event functions SetFrameSync/WaitFrameSync
+//					- Add data functions WriteMemoryBuffer/ReadMemoryBuffer
+//		07.04.21	- Close sync event in ReleaseSender
+//		20.04.21	- SendFbo - protect against SendFbo fail for default framebuffer if iconic
+//		24.04.21	- ReceiveTexture - return if flagged for update
+//					  only if there is a texture to receive into.
+//		10.05.21	- ReceiveTexture - allow for the possibility of 2.006 memoryshare sender.
+//		22.06.21	- Move code for GetSenderCount and GetSender to SpoutSenderNames class
+//		03.07.21	- Use changed SpoutSenderNames "GetSender" function name.
+//		04.07.21	- Additional code comments concerning update in ReceiveTexture.
+//		12.08.21	- CreateReceiver - Revise CreateReceiver to avoid switch to active
+//					  if the selected sender closes.
+//		15.10.21	- Allow no argument for SetReceiverName
+//		07.11.21	- Remove pbo available flag to use ReadGLDXpixels in ReceiveImage
+//					  it is tested within ReadGLDXpixels
+//		20.11.21	- Destructor virtual for base class
+//		22.11.21	- Use SpoutDirectX ReleaseDX11Texture to release shared texture
+//					- Remove adapter gets from constructor
+//		17.12.21	- Remove adapter gets from Sender/Receiver init
+//					  Adapter index and name are retrieved with Get functions
+//		20.12.21	- Restore log notice for ReleaseSender
+//		24.02.22	- Restore GetSenderAdapter for testing
+//		10.04.22	- ReceiveSenderData() - correct duplication of DX9 formats
+//		16.04.22	- Add more log notices to GetSenderAdapter
+//		18.04.22	- Change default invert from true to false for fbo sending functions
+//		28.04.22	- SelectSenderPanel - if SpoutPanel is not found,
+//					  show a MessageBox and direct to the Spout home page
+//		05.05.22	- SendFbo - mods for default framebuffer
+//		30.07.22	- SendFbo - avoid using glGetIntegerv if width and height are passed in
+//				      Revert to default invert true after further testing with default framebuffer.
+//		28.10.22	- Add GetPerformancePreference, SetPerformancePreference, GetPreferredAdapterName
+//		01.11.22	- Add SetPreferredAdapter
+//		03.11.22	- Add IsPreferenceAvailable
+//					  SetAdapter - GL/DX compatibility is re-tested in OpenSpout
+//		07.11.22	- Add IsApplicationPath
+//					  Update ReceiveSenderData code comments for Windows Graphics Preferences
+//		28.11.22	- SelectSenderPanel - correct warning if SpoutPanel is not found instead of the 
+//					  ShellExecute Windows error and allow user the option to open the Spout home page.
+//		05.12.22	- Add CleanSenders to SetSenderName
+//		07.12.22	- SelectSender return bool
+//		12.12.22	- SetSenderName - return if the same name
+//		13.12.22	- SetSenderName revise for null name passed
+//		14.12.22	- Remove SetAdapter. Requires OpenGL setup.
+//		18.12.22	- Change unused bDX9 argument to const with default
+//		20.12.22	- More checks for null arguments
+//		22.12.22	- Compiler compatibility check
+//				      Conditional compile of preference functions
+//		06.01.23	- UIntToPtr for cast of uint32_t to HANDLE
+//					  cast unsigned int array for glGetIntegerv instead of result
+//					  Avoid c-style cast where possible
+//		08.01.23	- Code review - Use Microsoft Native Recommended rules
+//		08.03.23	- GetSenderAdapter use SetAdpater instead of SetAdapterPointer
+//		21.03.23	- ReceiveSenderData - use the format of the D3D11 texture generated
+//					  by OpenDX11shareHandle for incorrect sender information.
+//	Version 2.007.011
+//		22.04.23	- Minor code comments cleanup
+//		29.04.23	- ReceiveSenderData - test for incorrect sender dimensions
+//		07.05.23	- CheckSender - release interop device and object to re-create
+//		17.05.23	- ReleaseSender - add m_bInitialized = false and remove from SpoutGL::GleanupGL
+//		18.05.23	- ReleaseSender - clear m_SenderName
+//		28.06.23	- Remove bDX9 option from GetAdapterInfo
+//		03.07.23	- CreateReceiver - remove unused bUseActive flag
+//					  and UNREFERENCED_PARAMETER (#PR93  Fix MinGW error(beta branch)
+//		22.07.23	- ReceiveSenderData -
+//					  ensure m_pSharedTexture is null if OpenSharedResource failed.
+//		03.08.23	- InitReceiver - set m_DX11format
+//		07.08.23	- Add frame sync option functions
+//	Version 2.007.012
+//		09.10.23	- SelectSenderPanel -if SpoutPanel.exe is not found
+//					  show a SpoutMessageBox with Spout releases page url
+//		18.10.23	- ReceiveSenderData - check for texture format supported
+//					  by OpenGL/DirectX interop
+//		07.12.23	- use _access in place of shlwapi Path functions
+//	Version 2.007.013
+//		14.01.24	- CheckSender - return false if OpenSpout fails
+//		13.02.24	- SelectSenderPanel
+//					  m_ShExecInfo.lpParameters : receiver graphics adapter index by default
+//		19.04.24	- SelectSenderPanel - allow for unicode build for PROCESSENTRY32
+//		24.04.24	- ReceiveImage - allow for multiple OpenGL formats
+//		06.05.24	- SelectSenderPanel - removed unused "value" variable
+//		21.05.24	- SetSenderName - move sender name increment to SenderNames class
+//		22.05.24	- Add GetReceiverName
+//					  CheckSpoutPanel - do not to register twice if already registered
+//		25.05.24	- SetSenderName - remove name increment
+//		08.06.24	- Add GetSenderList
+//		09.06.24	- SelectSender - use SpoutMessageBox if SelectSenderPanel fails
+//					  Add hwnd argument to centre MessageBox dialog if used.
+//	Version 2.007.014
+//		13.06.24	- SelectSender - open SpoutMessagebox for no senders.
+//					  Add OK/CANCEL and test for empty senderlist.
+//		21.06.24	- Add GetSenderIndex
+//					  Modify SelectSender to show the active sender as current
+//		03.07.24	- SelectSender - pass hWnd to SpoutPanel command line
+//					  for it to open centred on the window
+//		04.07.24	- CheckSpoutPanel - allow for use of SpoutMessageBox
+//		15.07.24	- SelectSender - after cast of window handle to long 
+//					  convert to a string of 8 characters without new line
+//		16.07.24	- Add receiver ID3D11Texture2D* GetSenderTexture()
+//		21.08.24	- SetPerformancePreference - remove null path test
+//		23.08.24	- SelectSender - if no SpoutPanel and SpoutMessageBox is used :
+//					  test for successful open of the sender share handle
+//					   - Warn if NT share handle
+//					   - Warn for open failure
+//					   - Allow setting preferences for laptop
+//					   - Allow sender adapter test for desktop
+//					   - Refer to Spout settings if no resolution or a desktop system
+//					  Also warn in SpoutPanel
+//
+// ====================================================================================
+/*
+
+	Copyright (c) 2014-2024, Lynn Jarvis. All rights reserved.
+
+	Redistribution and use in source and binary forms, with or without modification, 
+	are permitted provided that the following conditions are met:
+
+		1. Redistributions of source code must retain the above copyright notice, 
+		   this list of conditions and the following disclaimer.
+
+		2. Redistributions in binary form must reproduce the above copyright notice, 
+		   this list of conditions and the following disclaimer in the documentation 
+		   and/or other materials provided with the distribution.
+
+	THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"	AND ANY 
+	EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES 
+	OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE	ARE DISCLAIMED. 
+	IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
+	INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, 
+	PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+	LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+	OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+#include "Spout.h"
+
+
+// Class: Spout
+//
+// <https://spout.zeal.co/>
+//
+// Main class for Spout OpenGL texture sharing
+//
+// Contains both Sender and Receiver functions.
+//
+// This class and other source files are included in a project
+//
+// Files required are (.h and .cpp) :
+//
+// - Spout
+// - SpoutCommon
+// - SpoutCopy
+// - SpoutDirectX
+// - SpoutFramecount
+// - SpoutGL
+// - SpoutGLextensions
+// - SpoutSenderNames
+// - SpoutSharedMemory
+// - SpoutUtils
+//
+// Note that Sender and Receiver functions cannot be used within the same object.
+// The SpoutSender and SpoutReceiver classes are convenience wrappers which assist
+// the programmer by exposing only sender or receiver specific functions.
+//
+// - SpoutSender
+// - SpoutReceiver
+//
+// You can also use the Spout SDK as a dll. To build the dll, refer to the 
+// Visual Studio project in the VS2017 folder and the CMake build documentation.
+// Also refer to the SpoutLibrary folder for a C-compatible dll which can be 
+// used with compilers other than Visual Studio.
+//
+// For conversion of existing 2.006 applications, refer to "Porting.txt" in the "Docs" section
+// as well as the introductory document *SpoutSDK_2007.pdf*.
+//
+// More detailed information can be found in the header files for each class.
+// Functions for individual classes are documented within the respective source files.
+// You can access these from the following objects that are included in the Spout class.
+//
+// - spoutDirectX spoutdx; (DirectX 11 texture sharing)
+// - spoutCopy spoutcopy; (Pixel data copy)
+// - spoutSenderNames sendernames; (Spout sender management)
+// - spoutFrameCount frame; (Frame counting management)
+//
+// Details for practical use can be found in the source code for the Openframeworks examples.
+// The methods are simple and you should be able to quickly extend to your own application
+// or to other frameworks.
+//
+// Refer to the SpoutGL base class for further documentation and details.
+//
+Spout::Spout()
+{
+	// Initialize adapter name global
+	// Adapter index and name are retrieved with create sender or receiver
+	m_AdapterName[0] = 0;
+	m_bAdapt = false; // Receiver adapt to the sender adapter
+
+}
+
+Spout::~Spout()
+{
+	// ~spoutGL will release dependent objects
+}
+
+//
+// Group: Sender
+//
+// SendFbo, SendTexture and SendImage create or update a sender as required.
+//
+// - If a sender has not been created yet :
+//
+//    - Make sure Spout has been initialized and OpenGL context is available
+//    - Perform a compatibility check for GL/DX interop
+//    - If compatible, create interop for GL/DX transfer
+//    - If not compatible, create a DirectX 11 shared texture for the sender
+//    - Create a sender using the DX11 shared texture handle
+//
+// - If the sender exists, test for size change :
+//
+//    - If compatible, update the shared textures and GL/DX interop
+//    - If not compatible, re-create the class DirectX shared texture to the new size
+//    - Update the sender and class variables	
+//
+
+//---------------------------------------------------------
+// Function: SetSenderName
+// Set name for sender creation
+//
+// If no name is specified, the executable name is used. 
+// Thereafter, all sending functions create and update a sender
+// based on the size passed and the name that has been set.
+// If a sender with this name is already registered,
+// create an incremented name : sender_1, sender_2 etc.
+// and update the passed name
+void Spout::SetSenderName(const char* sendername)
+{
+	if (!sendername) {
+		// Get executable name as default
+		strcpy_s(m_SenderName, 256, GetExeName().c_str());
+	}
+	else {
+		strcpy_s(m_SenderName, 256, sendername);
+	}
+
+	// Create an incremented name if a sender with this name is already registered,
+	// Although this function precedes SpoutSenderNames::RegisterSenderName,
+	// a further increment is not applied when a sender with the new name is created.
+	char name[256]{};
+	strcpy_s(name, 256, m_SenderName);
+	if (sendernames.FindSenderName(name)) {
+		int i = 1;
+		do {
+			sprintf_s(name, 256, "%s_%d", m_SenderName, i);
+			i++;
+		} while (sendernames.FindSenderName(name));
+		// Re-set the global sender name
+		strcpy_s(m_SenderName, 256, name);
+	}
+
+	// Remove the sender from the names list if it's
+	// shared memory information does not exist.
+	// This can happen if the sender has crashed or if a
+	// console window was closed instead of the main program.
+	sendernames.CleanSenders();
+
+
+}
+
+//---------------------------------------------------------
+// Function: SetSenderFormat
+// Set the sender DX11 shared texture format
+//    Compatible formats - see SpoutGL::SetDX11format(DXGI_FORMAT textureformat)
+void Spout::SetSenderFormat(DWORD dwFormat)
+{
+	m_dwFormat = dwFormat;
+	// Update SpoutGL class global texture format
+	SetDX11format(static_cast<DXGI_FORMAT>(dwFormat));
+}
+
+//---------------------------------------------------------
+// Function: ReleaseSender
+// Close sender and release resources.
+//
+// A new sender is created or updated by all sending functions
+void Spout::ReleaseSender()
+{
+	SpoutLogNotice("Spout::ReleaseSender(%s)", m_SenderName);
+
+	if (m_bInitialized) {
+		sendernames.ReleaseSenderName(m_SenderName);
+		m_SenderName[0]=0;
+		frame.CleanupFrameCount();
+		frame.CloseAccessMutex();
+		m_bInitialized = false;
+	}
+
+	// Close 2.006 or buffer shared memory if used
+	memoryshare.Close();
+
+	// Release sync event if used
+	frame.CloseFrameSync();
+
+	// Interop objects must be released before releasing shared texture
+	CleanupInterop();
+
+	// Release OpenGL resources
+	CleanupGL();
+
+}
+
+//---------------------------------------------------------
+// Function: SendFbo
+// Send texture attached to fbo
+//
+//   The fbo must be bound for read. 
+//
+//   The sending texture can be larger than the size that the sender is set up for
+//   For example, if the application is using only a portion of the allocated texture space,  
+//   such as for Freeframe plugins. (The 2.006 equivalent is DrawToSharedTexture)
+//
+//   To send the default OpenGL framebuffer, specify FboID = 0. 
+//   If width and height are also 0, the function determines the viewport size. 
+//
+bool Spout::SendFbo(GLuint FboID, unsigned int fbowidth, unsigned int fboheight, bool bInvert)
+{
+	// For texture sharing, the size of the texture attached to the
+	// fbo must be equal to or larger than the shared texture
+	// Establish local width and height in case the viewport size is used
+	unsigned int width  = fbowidth;
+	unsigned int height = fboheight;
+
+	// For the default framebuffer, specify FboID = 0
+	if (FboID == 0) {
+		// Default framebuffer fails if iconic
+		if (IsIconic(m_hWnd))
+			return false;
+		// This additional test allows the application to get the viewport size 
+		// only when necessary to prevent repeated calls to glGetIntegerv if
+		// performance is affected.
+		if (width == 0 || height == 0) {
+			// Get the viewport size
+			unsigned int vpdims[4]={0};
+			glGetIntegerv(GL_VIEWPORT, (GLint*)vpdims);
+			width  = vpdims[2];
+			height = vpdims[3];
+		}
+	}
+
+	// Create or update the sender
+	if (!CheckSender(width, height)) {
+		return false;
+	}
+
+	// All clear to send the fbo texture
+	if(m_bTextureShare) {
+		// 3840-2160 - 60fps (0.45 msec per frame)
+		return WriteGLDXtexture(0, 0, width, height, bInvert, FboID);
+	}
+	else if (m_bCPUshare) {
+		// Auto share enabled for DirectX CPU backup
+		// 3840-2160 - 43fps (5-7msec/frame)
+		// Create a local class texture if not already
+		CheckOpenGLTexture(m_TexID, GL_RGBA, width, height);
+		// Copy from the texture attached to the bound fbo to the class texture
+		glBindTexture(GL_TEXTURE_2D, m_TexID);
+		glCopyTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, 0, 0, width, height);
+		glBindTexture(GL_TEXTURE_2D, 0);
+		// Copy from the OpenGL class texture to the shared DX11 texture by way of staging texture
+		return WriteDX11texture(m_TexID, GL_TEXTURE_2D, width, height, bInvert, FboID);
+	}
+
+	return false;
+
+}
+
+//---------------------------------------------------------
+// Function: SendTexture
+// Send OpenGL texture
+//
+//     SendTexture creates a shared texture for all receivers to access.
+//
+//     The invert flag is optional and by default true. This flips the texture
+//     in the Y axis, which is necessary because DirectX and OpenGL textures
+//     are opposite in Y. If it is set to false no flip occurs and the result
+//     may appear upside down.
+//
+//     The ID of a currently bound fbo should be passed in.
+//
+bool Spout::SendTexture(GLuint TextureID, GLuint TextureTarget,
+	unsigned int width, unsigned int height, bool bInvert, GLuint HostFBO)
+{
+	// Quit if no data
+	if (TextureID <= 0 || width == 0 || height == 0)
+		return false;
+
+	// Create or update the sender
+	if (!CheckSender(width, height))
+		return false;
+
+	if (m_bTextureShare) { // if GL/DX interop compatible
+		// Send OpenGL texture 
+		// 3840-2160 - 60fps (0.45 msec per frame)
+		return WriteGLDXtexture(TextureID, TextureTarget, width, height, bInvert, HostFBO);
+	}
+	else if (m_bCPUshare) {
+		// Auto share enabled for DirectX CPU backup
+		// 3840-2160 47fps (6-7 msec per frame with PBOs)
+		return WriteDX11texture(TextureID, TextureTarget, width, height, bInvert, HostFBO);
+	}
+
+	return false;
+
+}
+
+//---------------------------------------------------------
+// Function: SendImage
+// Send pixel image
+//
+//     SendImage creates a shared texture using image pixels as the source
+//     instead of an OpenGL texture. The format of the image to be sent is RGBA 
+//     by default but can be a different OpenGL format, for example GL_RGB or GL_BGRA_EXT.
+//
+//     The invert flag is optional and false by default.
+//
+//     The ID of a currently bound fbo should be passed in.
+//
+bool Spout::SendImage(const unsigned char* pixels, unsigned int width, unsigned int height, GLenum glFormat, bool bInvert, GLuint HostFBO)
+{
+	// Dimensions should be the same as the sender
+	if (!pixels || width == 0 || height == 0)
+		return false;
+
+	// Only RGBA, BGRA, RGB, BGR supported
+	// (DX11 format DXGI_FORMAT_B8G8R8A8_UNORM)
+	if (!(glFormat == GL_RGBA || glFormat == GL_BGRA_EXT || glFormat == GL_RGB || glFormat == GL_BGR_EXT))
+		return false;
+
+	// Check for BGRA support
+	GLenum glformat = glFormat;
+	if (!m_bBGRAavailable) {
+		SpoutLogWarning("Spout::SendImage - BGRA extensions not available");
+		// If the bgra extensions are not available and the user
+		// provided GL_BGR_EXT or GL_BGRA_EXT do not use them
+		if (glFormat == GL_BGR_EXT) glformat = GL_RGB;
+		if (glFormat == GL_BGRA_EXT) glformat = GL_RGBA;
+	}
+	
+	// Create or update the sender
+	if (!CheckSender(width, height))
+		return false;
+
+	//
+	// Write pixel data to the rgba shared texture according to pixel format
+	//
+	if (m_bTextureShare) {
+		// Texture share compatible
+		return WriteGLDXpixels(pixels, width, height, glformat, bInvert, HostFBO);
+	}
+	else if (m_bCPUshare) {
+		// Auto share enabled for DirectX CPU backup
+		return WriteDX11pixels(pixels, width, height, glformat, bInvert);
+	}
+
+	return false;
+
+}
+
+//---------------------------------------------------------
+// Function: IsInitialized
+// Initialization status
+bool Spout::IsInitialized()
+{
+	return m_bInitialized;
+}
+
+//---------------------------------------------------------
+// Function: GetName
+// Sender name
+const char * Spout::GetName()
+{
+	return m_SenderName;
+}
+
+//---------------------------------------------------------
+// Function: GetWidth
+// Sender width
+unsigned int Spout::GetWidth()
+{
+	return m_Width;
+}
+
+//---------------------------------------------------------
+// Function: GetHeight
+// Sender height
+unsigned int Spout::GetHeight()
+{
+	return m_Height;
+}
+
+//---------------------------------------------------------
+// Function: GetFps
+// Sender frame rate
+double Spout::GetFps()
+{
+	return frame.GetSenderFps();
+}
+
+//---------------------------------------------------------
+// Function: GetFrame
+// Sender frame number
+long Spout::GetFrame()
+{
+	return frame.GetSenderFrame();
+}
+
+//---------------------------------------------------------
+// Function: GetHandle
+// Sender share handle
+HANDLE Spout::GetHandle()
+{
+	return m_dxShareHandle;
+}
+
+//---------------------------------------------------------
+// Function: GetCPU
+// Sender sharing method.
+//   Returns true if the sender is using CPU methods
+bool Spout::GetCPU()
+{
+	return m_bSenderCPU;
+}
+
+//---------------------------------------------------------
+// Function: GetGLDX
+// Sender sharing compatibility.
+//  Returns true if the sender graphics hardware is 
+//  compatible with NVIDIA NV_DX_interop2 extension
+bool Spout::GetGLDX()
+{
+	return m_bSenderGLDX;
+}
+
+
+//
+// Group: Receiver
+//
+// Receiving functions
+//
+// ReceiveTexture and ReceiveImage 
+//
+//		- Connect to a sender
+//
+//		- Set class variables for sender name, width and height
+//
+//		- If the sender has changed size, set a flag for the application to update the receiving texture or image if IsUpdated() returns true.
+//
+//		- Copy the sender shared texture to the user texture or image.
+//
+// Any changes to sender size are managed. However, if you are receiving to a local texture or image,
+// the application must check for update at every cycle before receiving any data using "IsUpdated()"
+
+//---------------------------------------------------------
+// Function: SetReceiverName
+// Specify sender for connection
+//
+//   The if a name is specified, the receiver will not connect to any other unless the user selects one
+//   If that sender closes, the receiver will wait for the nominated sender to open 
+//   If no name is specified, the receiver will connect to the active sender
+void Spout::SetReceiverName(const char * SenderName)
+{
+	if (SenderName) {
+		if (*SenderName) {
+			// Connect to the specified sender
+			strcpy_s(m_SenderNameSetup, 256, SenderName);
+			strcpy_s(m_SenderName, 256, SenderName);
+			return;
+		}
+	}
+
+	// Connect to the active sender
+	m_SenderNameSetup[0] = 0;
+	m_SenderName[0] = 0;
+
+}
+
+//---------------------------------------------------------
+// Function: GetReceiverName
+// Get sender for connection
+bool Spout::GetReceiverName(char* sendername, int maxchars)
+{
+	if (m_SenderNameSetup[0]) {
+		strcpy_s(sendername, maxchars, m_SenderNameSetup);
+		return true;
+	}
+	return false;
+}
+
+//---------------------------------------------------------
+// Function: ReleaseReceiver
+// Close receiver and release resources ready to connect to another sender
+void Spout::ReleaseReceiver()
+{
+	if (!m_bInitialized)
+		return;
+
+	SpoutLogNotice("Spout::ReleaseReceiver");
+
+	// Release interop
+	CleanupInterop();
+
+	// Release OpenGL resources.
+	CleanupGL();
+
+	// Restore the starting sender name if the user specified one in SetReceiverName
+	if (m_SenderNameSetup[0]) {
+		strcpy_s(m_SenderName, 256, m_SenderNameSetup);
+	}
+	else {
+		m_SenderName[0] = 0;
+	}
+
+	// Wait 4 frames in case the same sender opens again
+	Sleep(67);
+
+	// Close the named access mutex and frame counting semaphore.
+	frame.CloseAccessMutex();
+	frame.CleanupFrameCount();
+
+	// Zero width and height so that they are reset when a sender is found
+	m_Width = 0;
+	m_Height = 0;
+
+	// Close shared memory and sync event if used
+	memoryshare.Close();
+	frame.CloseFrameSync();
+
+	m_bConnected = false;
+	m_bInitialized = false;
+
+
+}
+
+//---------------------------------------------------------
+// Function: ReceiveTexture
+//     Connect to a sender and retrieve shared texture details
+bool Spout::ReceiveTexture()
+{
+	return ReceiveTexture(0, 0);
+}
+
+//---------------------------------------------------------
+// Function: ReceiveTexture
+//   Receive the sender shared texture
+//
+//   For a valid OpenGL receiving texture :
+//
+//   Copy from the sender shared texture if there is a texture to receive into.
+//   The receiving OpenGL texture can only be RGBA of dimension (width * height)
+//   and must be re-allocated for sender size change. Return if flagged for update.
+//   The update flag is reset when the receiving application calls IsUpdated().
+//
+//   If no arguments are passed :
+//
+//   Connect to a sender and retrieve shared texture details,
+//	 initialize GL/DX interop for OpenGL texture access, and update
+//   the sender shared texture, frame count and framerate.
+//   The texture can then be accessed using :
+//
+//		- BindSharedTexture();
+//		- UnBindSharedTexture();
+//		- GetSharedTextureID();
+//
+//   As with SendTexture, the host fbo argument is optional (default 0)
+//   but an fbo ID is necessary if it is currently bound, then that binding
+//   is restored. Otherwise the binding is lost.
+//
+bool Spout::ReceiveTexture(GLuint TextureID, GLuint TextureTarget, bool bInvert, GLuint HostFbo)
+{
+	// Return if flagged for update and there is a texture to receive into.
+	// The update flag is reset when the receiving application calls IsUpdated().
+	if (m_bUpdated && TextureID != 0 && TextureTarget != 0) {
+		return true;
+	}
+
+	// Make sure OpenGL and DirectX are initialized
+	if (!OpenSpout()) {
+		return false;
+	}
+	// Try to receive texture details from a sender
+	if (ReceiveSenderData()) {
+
+		// Found a sender
+		// The sender name, width, height, format, shared texture handle
+		// and shared texture pointer have been retrieved
+		// Let the application know
+		m_bConnected = true;
+
+		// If the connected sender sharehandle or name is different,
+		// the receiver is re-initialized and m_bUpdated is set true
+		// so that the application re-allocates the receiving texture.
+		if (m_bUpdated) {
+
+			// If the sender is new or changed, reset shared/linked textures
+			if (m_bTextureShare) {
+
+				// CreateInterop set "true" for receiver
+				if (!CreateInterop(m_Width, m_Height, m_dwFormat, true)) {
+					return false;
+				}
+			}
+	
+			// If receiving to a texture, return to update it.
+			// The application detects the change with IsUpdated().
+			if (TextureID != 0 && TextureTarget != 0) {
+				return true;
+			}
+
+			// m_bUpdated is reset to false on the next call to 
+			// ReceiveSenderData until the sender changes size again
+
+		}
+
+		// Was the sender's shared texture handle null
+		// or has the user set 2.006 memoryshare mode?
+		if (!m_dxShareHandle || m_bMemoryShare) {
+			// Possible existence of 2.006 memoryshare sender (no texture handle)
+			// (ReadMemoryTexture currently only works if texture share compatible)
+			if (m_bTextureShare) {
+				if (ReadMemoryTexture(m_SenderName, TextureID, TextureTarget, m_Width, m_Height, bInvert, HostFbo)) {
+					return true;
+				}
+			}
+			// ReadMemoryTexture failed, is there is a texture share handle ?
+			if (!m_dxShareHandle) {
+				return false;
+			}
+			// This could be a 2.007 sender but the user has set 2.006 memoryshare mode
+			// Drop though
+		}
+
+		if (m_bTextureShare) {
+			// Texture share compatible
+			// 3840x2160 60 fps - 0.45 msec/frame
+			ReadGLDXtexture(TextureID, TextureTarget, m_Width, m_Height, bInvert, HostFbo);
+		}
+		else if (m_bCPUshare) {
+			// Auto share enabled for DirectX CPU backup
+			// 3840x2160 33 fps - 5-7 msec/frame
+			ReadDX11texture(TextureID, TextureTarget, m_Width, m_Height, bInvert, HostFbo);
+		}
+	} // endif sender exists
+	else {
+		// ReceiveSenderData fails if there is no sender or the connected sender closed.
+		ReleaseReceiver();
+		// Let the application know.
+		m_bConnected = false;
+	}
+
+	return m_bConnected;
+}
+
+//---------------------------------------------------------
+// Function: ReceiveImage
+// Copy the sender texture to image pixels.
+//
+//    Formats supported are : GL_RGBA, GL_RGB, GL_BGRA_EXT, GL_BGR_EXT.
+//    GL_BGRA_EXT and GL_BGR_EXT are dependent on those extensions being supported at runtime.
+//    If they are not, the rgba and rgb equivalents are used.
+//    The same sender size changes are handled with IsUpdated() as for ReceiveTexture.
+//    and the receiving buffer must be re-allocated if IsUpdated() returns true.
+//    NOTE : images with padding on each line are not supported.
+//    Also the width should be a multiple of 4
+//
+//    As with ReceiveTexture, the ID of a currently bound fbo should be passed in.
+//
+bool Spout::ReceiveImage(char* Sendername, unsigned int &width, unsigned int &height,
+	unsigned char* pixels, GLenum glFormat, bool bInvert, GLuint HostFBO)
+{
+	if (!pixels || !Sendername)
+		return false;
+
+	if (ReceiveImage(pixels, glFormat, bInvert, HostFBO)) {
+		strcpy_s(Sendername, 256, m_SenderName);
+		width = m_Width;
+		height = m_Height;
+		return true;
+	}
+	return false;
+}
+
+//---------------------------------------------------------
+// Function: IsUpdated
+// Query whether the sender has changed.
+//
+//   Must be checked at every cycle before receiving data. 
+//   If this is not done, the receiving functions fail.
+//
+bool Spout::IsUpdated()
+{
+	const bool bRet = m_bUpdated;
+	m_bUpdated = false; // Reset the update flag
+	return bRet;
+}
+
+//---------------------------------------------------------
+// Function: IsConnected
+// Query sender connection.
+//
+//   If the sender closes, receiving functions return false,  
+//   but connection can be tested at any time.
+//
+bool Spout::IsConnected()
+{
+	return m_bConnected;
+}
+
+//---------------------------------------------------------
+// Function: IsFrameNew
+// Query received frame status
+//
+//   The receiving texture or pixel buffer is refreshed if the sender has produced a new frame  
+//   This can be queried to process texture data only for new frames
+bool Spout::IsFrameNew()
+{
+	return frame.IsFrameNew();
+}
+
+//---------------------------------------------------------
+// Function: GetSenderFormat
+// Get sender DirectX texture format
+DWORD Spout::GetSenderFormat()
+{
+	return m_dwFormat;
+}
+
+//---------------------------------------------------------
+// Function: GetSenderName
+// Get sender name
+const char * Spout::GetSenderName()
+{
+	return m_SenderName;
+}
+
+//---------------------------------------------------------
+// Function: GetSenderWidth
+// Get sender width
+unsigned int Spout::GetSenderWidth()
+{
+	return m_Width;
+}
+
+//---------------------------------------------------------
+// Function: GetSenderHeight
+// Get sender height
+unsigned int Spout::GetSenderHeight()
+{
+	return m_Height;
+
+}
+
+//---------------------------------------------------------
+// Function: GetSenderFps
+// Get sender frame rate
+double Spout::GetSenderFps()
+{
+	return frame.GetSenderFps();
+}
+
+//---------------------------------------------------------
+// Function: GetSenderFrame
+// Get sender frame number
+long Spout::GetSenderFrame()
+{
+	return frame.GetSenderFrame();
+}
+
+//---------------------------------------------------------
+// Function: GetSenderHandle
+// Received sender share handle
+HANDLE Spout::GetSenderHandle()
+{
+	return m_dxShareHandle;
+}
+
+//---------------------------------------------------------
+// Function: GetSenderTexture
+// Received sender texture
+ID3D11Texture2D* Spout::GetSenderTexture()
+{
+	return m_pSharedTexture;
+}
+
+//---------------------------------------------------------
+// Function: GetSenderCPU
+// Received sender sharing method.
+//   Returns true if the sender is using CPU methods
+bool Spout::GetSenderCPU()
+{
+	return m_bSenderCPU;
+}
+
+//---------------------------------------------------------
+// Function: GetSenderGLDX
+// Received sender sharing compatibility.
+//   Returns true if the sender graphics hardware is 
+//   compatible with NVIDIA NV_DX_interop2 extension
+bool Spout::GetSenderGLDX()
+{
+	return m_bSenderGLDX;
+}
+
+//---------------------------------------------------------
+// Function: SelectSender
+// Open sender selection dialog
+bool Spout::SelectSender(HWND hwnd)
+{
+	//
+	// Use SpoutPanel if available
+	//
+	// SpoutPanel opens either centred on the cursor position 
+	// or on the application window if the handle is passed in.
+
+	// For a valid window handle, convert hwnd to chars
+	// for the SpoutPanel command line
+	char * msg = nullptr;
+	if (hwnd) {
+		// Window handle is an 32 bit unsigned value
+		// Cast to long of 8 characters without new line
+		msg = new char[256];
+		sprintf_s(msg, 256, "%8.8ld", HandleToLong(hwnd));
+	}
+
+	if (!SelectSenderPanel(msg)) {
+
+		// If SpoutPanel is not available, use a SpoutMessageBox for sender selection.
+		// Note that SpoutMessageBox is modal and will interrupt the host program.
+
+		// create a local sender list
+		std::vector<std::string> senderlist = GetSenderList();
+	
+		// Get the active sender index "selected".
+		// The index is passed in to SpoutMessageBox and used as the current combobox item.
+		int selected = 0;
+		char sendername[256]{};
+		if (GetActiveSender(sendername))
+			selected = GetSenderIndex(sendername);
+
+		// SpoutMessageBox opens either centred on the cursor position 
+		// or on the application window if the handle is passed in.
+		if (!hwnd) {
+			POINT pt={};
+			GetCursorPos(&pt);
+			SpoutMessageBoxPosition(pt);
+		}
+
+		// Show the SpoutMessageBox even if the list is empty.
+		// This makes it clear to the user that no senders are running.
+		if (SpoutMessageBox(hwnd, NULL, "Select sender", MB_OKCANCEL, senderlist, selected) == IDOK && !senderlist.empty()) {
+
+			// Release the receiver
+			ReleaseReceiver();
+
+			// Set the selected sender as active for the next receive
+			SetActiveSender(senderlist[selected].c_str());
+
+			//
+			// Test for successful open of the sender share handle
+			//
+			// - Warn if NT share handle
+			// - Warn for open failure
+			// - Allow setting preferences for laptop
+			// - Allow sender adapter test for desktop
+			// - Refer to Spout settings if no resolution or a desktop system
+			SharedTextureInfo info{};
+			if (sendernames.getSharedInfo(senderlist[selected].c_str(), &info)) {
+				std::string str;
+				ID3D11Texture2D* pTexture = nullptr;
+				if (spoutdx.OpenDX11shareHandle(spoutdx.GetDX11Device(), &pTexture, LongToHandle((long)info.shareHandle))) {
+					// If OpenDX11shareHandle succeeded, sender and receiver use the same adapter
+					// Check for an NT handle
+					D3D11_TEXTURE2D_DESC desc{};
+					pTexture->GetDesc(&desc);
+					if (desc.MiscFlags & D3D11_RESOURCE_MISC_SHARED_KEYEDMUTEX) {
+						if (desc.MiscFlags & D3D11_RESOURCE_MISC_SHARED_NTHANDLE) {
+							str = "NT handle shared texture not supported\n";
+							SpoutMessageBox(hwnd, str.c_str(), "Warning", MB_OK | MB_ICONWARNING);
+						}
+					}
+					spoutdx.ReleaseDX11Texture(pTexture);
+				}
+				else {
+					str ="WARNING - failed to open texture share handle\n\n";
+					if (IsLaptop()) {
+						str += "Laptop system detected.\n\n";
+						str += "<a href=\"ms-settings:display-advancedgraphics\">Windows Graphics Performance Preferences</a>\n";
+						// Windows preferences for laptop power saving graphics
+						//     -1 - No preference
+						//      0 - Default
+						//      1 - Power saving
+						//      2 - High performance
+						char senderpath[512]{};
+						strcpy_s(senderpath, 512, (char*)info.description);
+						if (_access(senderpath, 0) != -1) {
+							// Sender
+							int senderpref = GetPerformancePreference(senderpath);
+							// Receiver is this application
+							int receiverpref = GetPerformancePreference();
+							// If both are already set to high performance, there is another problem
+							if (senderpref == 2 && receiverpref == 2) {
+								str += "Both sender and receiver are already set\n";
+								str += "to prefer High performance.\n\n";
+								// General
+								str += "Open \"SpoutSettings\" and \"Reset\" for default settings\n";
+								str += "Click \"Diagnostics\" to show system details, and \"Logs\"\n";
+								str += "to explore application logs. If sender or receiver log files\n";
+								str += "are available, examine for Warnings and Errors.\n\n";
+								str += "Seek further assistance on the <a href=\"https://spout.discourse.group/\">Spout Discourse Group</a>\n\n";
+								SpoutMessageBox(hwnd, str.c_str(), "Warning", MB_OK | MB_ICONWARNING);
+							}
+							else {
+								str += "Both sender and receiver applications\n";
+								str += "must be set to prefer High performance.\n";
+								if (senderpref == -1 && receiverpref == -1) {
+									str += "    No preferences set\n";
+								}
+								else {
+									str += "    Sender    - ";
+									if (senderpref == -1) str += "  No preference set\n";
+									if (senderpref ==  0) str += "  Let Windows decide\n";
+									if (senderpref ==  1) str += "  Power saving\n";
+									if (senderpref ==  2) str += "  High performance\n";
+									str += "    Receiver - ";
+									if (receiverpref == -1) str += "  No preference set\n";
+									if (receiverpref ==  0) str += "  Let Windows decide\n";
+									if (receiverpref ==  1) str += "  Power saving\n";
+									if (receiverpref ==  2) str += "  High performance\n";
+									str += "\n";
+								}
+								str += "Change both sender and receiver\nto prefer High Performance now?\n\n";
+								if (SpoutMessageBox(hwnd, str.c_str(), "Warning", MB_YESNO | MB_ICONWARNING) == IDYES) {
+									// Sender
+									SetPerformancePreference(2, senderpath);
+									// Receiver
+									SetPerformancePreference(2);
+									SpoutMessageBox(hwnd, "Restart sender and receiver\nfor changes to take effect", "Information", MB_OK | MB_ICONINFORMATION);
+								}
+							}
+						}
+					} // endif laptop system
+					else {
+						int nadapters = GetNumAdapters();
+						str += "Desktop system with ";
+						str += std::to_string(nadapters);
+						if(nadapters == 1)
+							str += " graphics adapter.\n";
+						else
+							str += " graphics adapters.\n";
+						// List multiple graphics adapters
+						char adaptername[256]{};
+						for (int i=0; i<nadapters; i++) {
+							GetAdapterName(i, adaptername);
+							str += " ("; str += std::to_string(i); str += ") ";
+							str += adaptername; str += "\n";
+						}
+						str += "\n";
+						if (nadapters > 1) {
+							str += "Both sender and receiver applications\n";
+							str += "must use the same graphics adapter.\n";
+							// Get the receiver adapter name
+							int adapterindex = GetAdapter();
+							GetAdapterName(adapterindex, adaptername);
+							str += "Receiver - ";
+							str += " ("; str += std::to_string(adapterindex); str += ") ";
+							str += adaptername; str += "\n\n";
+							// Optional test for sender adapter
+							str += "Click \"Test\" below to find an adapter that opens the\n";
+							str += "texture share handle and compare with the receiver.\n";
+							str += "Note that this process can fail for some systems.\n\n";
+							SpoutMessageBoxButton(1000, L"Test");
+							if (SpoutMessageBox(hwnd, str.c_str(), "Warning", MB_OK | MB_ICONWARNING) == 1000) {
+								// Loop though adapters and get the Sender adapter index and name
+								char senderadaptername[256]{};
+								int senderadapter = GetSenderAdapter(senderlist[selected].c_str(), senderadaptername);
+								str = "Sender    - ";
+								str += " ("; str += std::to_string(senderadapter); str += ") ";
+								str += senderadaptername; str += "\n";
+								// Receiver index and adapter name
+								adapterindex = GetAdapter();
+								GetAdapterName(adapterindex, adaptername);
+								str += "Receiver - ";
+								str += " ("; str += std::to_string(adapterindex); str += ") ";
+								str += adaptername; str += "\n";
+								if (senderadapter == adapterindex) {
+									str += "\nReceiver and sender use the same graphics adapter\n";
+									SpoutMessageBox(hwnd, str.c_str(), "Graphics", MB_OK | MB_ICONINFORMATION);
+								}
+								else {
+									str += "\nReceiver and sender use different graphics adapters\n";
+									str += "Refer to the sender application documentation\n";
+									SpoutMessageBox(hwnd, str.c_str(), "Warning", MB_OK | MB_ICONWARNING);
+								}
+							}
+							str = ""; // Clear first message if multiple adapters
+						}
+
+						// General
+						str += "Open \"SpoutSettings\" and \"Reset\" for default settings\n";
+						str += "Click \"Diagnostics\" to show system details, and \"Logs\"\n";
+						str += "to explore application logs. If sender or receiver log files\n";
+						str += "are available, examine for Warnings and Errors.\n\n";
+						str += "Seek further assistance on the <a href=\"https://spout.discourse.group/\">Spout Discourse Group</a>\n\n";
+						SpoutMessageBox(hwnd, str.c_str(), "Settings", MB_OK | MB_ICONINFORMATION, "Spout settings");
+
+					} // endif desktop system
+				} // endif opensharehandle failed
+			} // endif senderinfo
+
+			// Set the opened flag in the same way as for SelectSenderPanel
+			// to indicate that the user has selected a sender.
+			// This is tested in CheckSpoutPanel.
+			m_bSpoutPanelOpened = true;
+		}
+	}
+	
+	if (msg) delete[] msg;
+
+	return true;
+
+
+}
+
+//
+// Group: Frame counting
+//
+
+//---------------------------------------------------------
+// Function: SetFrameCount
+// Enable or disable frame counting globally
+void Spout::SetFrameCount(bool bEnable)
+{
+	frame.SetFrameCount(bEnable);
+}
+
+// Function: DisableFrameCount
+// Disable frame counting specifically for this application
+void Spout::DisableFrameCount()
+{
+	frame.DisableFrameCount();
+}
+
+//---------------------------------------------------------
+// Function: IsFrameCountEnabled
+// Return frame count status
+bool Spout::IsFrameCountEnabled()
+{
+	return frame.IsFrameCountEnabled();
+}
+
+//---------------------------------------------------------
+// Function: HoldFps
+// Frame rate control.
+//    Desired frames per second.
+void Spout::HoldFps(int fps)
+{
+	frame.HoldFps(fps);
+}
+
+//
+// Group: Frame synchronization
+//
+//
+//   Notes for synchronisation.
+//
+//
+// In cases where the receiver or the sender have different processing or cycle rates
+// it is often necessary to synchronize one with the other to avoid missed or duplicate frames
+// and possible visible hesitations.
+//
+// This can be achieved using event functions "SetFrameSync" and "WaitFrameSync".
+//
+//      - void SetFrameSync(const char* SenderName);
+//      - bool WaitFrameSync(const char *SenderName, DWORD dwTimeout = 0);
+//
+//   WaitFrameSync
+//   A sender or receiver should use this before rendering wait for a signal from
+//   the other process that it is ready to send or to read another frame.
+//
+//   SetFrameSync
+//   After processing, a sender or receiver should signal that it is ready to
+//   either send or read another frame. 
+//
+// EXAMPLES
+//
+// 1) If the sender is faster, the slower receiver will miss frames.
+//
+//    Sender
+//    Before processing, the sender waits for a signal from the receiver that it is ready to receive a new frame.
+//        WaitFrameSync(const char* sendername, DORD dwTimeout);'
+//    Receiver
+//    After processing, signals the sender to produce a new frame.
+//        SetFrameSync(const char* sendername);
+//
+// 2) If the sender is slower, the faster receiver will duplicate frames.
+//
+//    Receiver
+//    Before processing, the receiver waits for a signal from the sender that a new frame is ready.
+//        WaitFrameSync(const char* sendername, DORD dwTimeout);
+//    Sender
+//        After processing, signals the receiver that a new frame is ready.
+//        SetFrameSync(const char* sendername);
+//
+
+// -----------------------------------------------
+// Function: SetFrameSync
+// Signal sync event.
+//   Create a named sync event and set for test
+void Spout::SetFrameSync(const char* SenderName)
+{
+	if (SenderName && *SenderName && m_bInitialized)
+		frame.SetFrameSync(SenderName);
+}
+
+// -----------------------------------------------
+// Function: WaitFrameSync
+// Wait or test for named sync event.
+// Wait until the sync event is signalled or the timeout elapses.
+// Events are typically created based on the sender name and are
+// effective between a single sender/receiver pair.
+//   - For testing for a signal, use a wait timeout of zero.
+//   - For synchronization, use a timeout greater than the expected delay
+// 
+bool Spout::WaitFrameSync(const char *SenderName, DWORD dwTimeout)
+{
+	if (!SenderName || !m_bInitialized)
+		return false;
+	return frame.WaitFrameSync(SenderName, dwTimeout);
+}
+
+// -----------------------------------------------
+// Function: EnableFrameSync
+// Enable / disabley frame sync
+void Spout::EnableFrameSync(bool bSync)
+{
+	frame.EnableFrameSync(bSync);
+}
+
+// -----------------------------------------------
+// Function: IsFrameSyncEnabled
+// Check for frame sync option
+bool Spout::IsFrameSyncEnabled()
+{
+	return frame.IsFrameSyncEnabled();
+}
+
+
+//
+// Group: Sender names
+//
+
+//---------------------------------------------------------
+// Function: GetSenderCount
+// Number of senders
+int Spout::GetSenderCount()
+{
+	return sendernames.GetSenderCount();
+}
+
+//---------------------------------------------------------
+// Function: GetSender
+// Sender item name in the sender names set
+bool Spout::GetSender(int index, char* sendername, int MaxSize)
+{
+	if (!sendername)
+		return false;
+	return sendernames.GetSender(index, sendername, MaxSize);
+}
+
+//---------------------------------------------------------
+// Function: GetSenderList
+// Return a list of current senders
+std::vector<std::string> Spout::GetSenderList()
+{
+	std::vector<std::string> list;
+	int nSenders = GetSenderCount();
+	if (nSenders > 0) {
+		char sendername[256]{};
+		for (int i=0; i<nSenders; i++) {
+			if (GetSender(i, sendername))
+				list.push_back(sendername);
+		}
+	}
+	return list;
+}
+
+//---------------------------------------------------------
+// Function: GetSenderIndex
+// Sender index into the set of names
+int Spout::GetSenderIndex(const char* sendername)
+{
+	return sendernames.GetSenderIndex(sendername);
+}
+
+//---------------------------------------------------------
+// Function: GetSenderInfo
+// Sender information
+bool Spout::GetSenderInfo(const char* sendername, unsigned int &width, unsigned int &height, HANDLE &dxShareHandle, DWORD &dwFormat)
+{
+	if (!sendername)
+		return false;
+	return sendernames.GetSenderInfo(sendername, width, height, dxShareHandle, dwFormat);
+}
+
+//---------------------------------------------------------
+// Function: GetActiveSender
+// Current active sender name
+bool Spout::GetActiveSender(char* Sendername)
+{
+	if (!Sendername)
+		return false;
+	return sendernames.GetActiveSender(Sendername);
+}
+
+//---------------------------------------------------------
+// Function: SetActiveSender
+// Set sender as active
+bool Spout::SetActiveSender(const char* Sendername)
+{
+	if (!Sendername)
+		return false;
+	return sendernames.SetActiveSender(Sendername);
+}
+
+//
+// Group: Graphics adapter
+//
+// Return graphics adapter number and names.
+// Refer to the SpoutDirectX class for details.
+//
+
+//---------------------------------------------------------
+// Function: GetNumAdapters
+// The number of graphics adapters in the system
+int Spout::GetNumAdapters()
+{
+	return spoutdx.GetNumAdapters();
+}
+
+//---------------------------------------------------------
+// Function: GetAdapterName
+// Get adapter item name
+bool Spout::GetAdapterName(int index, char *adaptername, int maxchars)
+{
+	char name[256]={};
+	if (spoutdx.GetAdapterName(index, name, 256)) {
+		strcpy_s(adaptername, maxchars, name);
+		return true;
+	}
+	return false;
+}
+
+//---------------------------------------------------------
+// Function: AdapterName
+// Return current adapter name
+char * Spout::AdapterName()
+{
+	GetAdapterName(spoutdx.GetAdapter(), m_AdapterName, 256);
+	return m_AdapterName;
+}
+
+//---------------------------------------------------------
+// Function: GetAdapter
+// Get current adapter index
+int Spout::GetAdapter()
+{
+	return spoutdx.GetAdapter();
+}
+
+//---------------------------------------------------------
+// Function: GetSenderAdapter
+// Get adapter index and name for a given sender
+//
+// OpenDX11shareHandle will fail if the share handle has been created 
+// using a different graphics adapter (see spoutDirectX).
+//
+// This function loops though all graphics adapters in the system
+// until OpenDX11shareHandle is successful and the same adapter
+// index as the sender is established. 
+//
+// This adapter can then be used by CreateDX11device when the Spout 
+// DirectX device is created. This can be done in DirectX applications
+// (see examples for the SpoutDX class), but not for OpenGL because both
+// OpenGL and DirectX must use the same adapter.
+//
+// The function is included here for diagnostic purposes.
+//
+int Spout::GetSenderAdapter(const char* sendername, char* adaptername, int maxchars)
+{
+	if (!sendername || !adaptername)
+		return -1;
+
+	int senderadapter = -1;
+	ID3D11Texture2D* pSharedTexture = nullptr;
+	ID3D11Device* pDummyDevice = nullptr;
+	ID3D11DeviceContext* pContext = nullptr;
+	IDXGIAdapter* pAdapter = nullptr;
+	SpoutLogNotice("Spout::GetSenderAdapter - testing for sender adapter (%s)", sendername);
+
+	SharedTextureInfo info={};
+	if (!sendernames.getSharedInfo(sendername, &info))
+		return -1;
+
+	// Get the current device adapter
+	const int adapterIndex = spoutdx.GetAdapter();
+	const int nAdapters = spoutdx.GetNumAdapters();
+	for (int i = 0; i < nAdapters; i++) {
+		pAdapter = spoutdx.GetAdapterPointer(i);
+		if (pAdapter) {
+			// Set the adapter for CreateDX11device to use temporarily
+			spoutdx.SetAdapter(i);
+			// Create a dummy device using this adapter
+			pDummyDevice = spoutdx.CreateDX11device();
+			if (pDummyDevice) {
+				// Try to open the share handle with the device created from the adapter
+				if (spoutdx.OpenDX11shareHandle(pDummyDevice, &pSharedTexture, UIntToPtr(info.shareHandle))) {
+					// break as soon as it succeeds
+					SpoutLogNotice("  found sender adapter %d(0x%.7X)[%s]", i, PtrToUint(pAdapter), adaptername);
+					senderadapter = i;
+					// Return the adapter name
+					spoutdx.GetAdapterName(i, adaptername, maxchars);
+					pDummyDevice->GetImmediateContext(&pContext);
+					if (pContext) pContext->Flush();
+					pDummyDevice->Release();
+					pAdapter->Release();
+					break;
+				}
+				SpoutLogNotice("    Could not open sender shared texture share handle for adapter %d", i);
+				pDummyDevice->GetImmediateContext(&pContext);
+				if (pContext) pContext->Flush();
+				pDummyDevice->Release();
+			}
+			SpoutLogNotice("    Could not create DX11 device for test");
+			pAdapter->Release();
+		}
+	}
+
+	// Set the SpoutDirectX class adapter back to what it was
+	spoutdx.SetAdapter(adapterIndex);
+
+	return senderadapter;
+
+}
+
+//---------------------------------------------------------
+// Function: GetAdapterInfo
+// Get the description and output name of the current adapter
+bool Spout::GetAdapterInfo(char* description, char* output, int maxchars)
+{
+	return spoutdx.GetAdapterInfo(description, output, maxchars);
+}
+
+//---------------------------------------------------------
+// Function: GetAdapterInfo
+// Get the description and output display name for a given adapter
+bool Spout::GetAdapterInfo(int index, char* description, char* output, int maxchars)
+{
+	return spoutdx.GetAdapterInfo(index, description, output, maxchars);
+}
+
+
+//
+// Group: Graphics performance
+//
+// Windows Graphics performance preferences.
+// Refer to the SpoutDirectX class for details.
+//
+// Performance prefrence settings are available from Windows 10
+// April 2018 update "Redstone 4" (Version 1803, build 17134) and later.
+// Windows 10 SDK required included in Visual Studio 2017 ver.15.7 
+//
+#ifdef NTDDI_WIN10_RS4
+
+//---------------------------------------------------------
+// Function: GetPerformancePreference
+// Get the Windows graphics preference for an application
+//
+//	-1 - Not registered
+//
+//	 0 - DXGI_GPU_PREFERENCE_UNSPECIFIED
+//
+//	 1 - DXGI_GPU_PREFERENCE_MINIMUM_POWER
+//
+//	 2 - DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE
+//
+int Spout::GetPerformancePreference(const char* path)
+{
+	return spoutdx.GetPerformancePreference(path);
+}
+
+//---------------------------------------------------------
+// Function: SetPerformancePreference
+// Set the Windows graphics preference for an application
+//
+//     -1 - No preference
+//
+//      0 - Default
+//
+//      1 - Power saving
+//
+//      2 - High performance
+//
+bool Spout::SetPerformancePreference(int preference, const char* path)
+{
+	return spoutdx.SetPerformancePreference(preference, path);
+}
+
+//---------------------------------------------------------
+// Function: GetPreferredAdapterName
+//
+// Get the graphics adapter name for a Windows preference
+// This is the first adapter for the given preference :
+//
+//    DXGI_GPU_PREFERENCE_UNSPECIFIED - (0) Equivalent to EnumAdapters1
+//
+//    DXGI_GPU_PREFERENCE_MINIMUM_POWER - (1) Integrated GPU
+//
+//    DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE - (2) External GPU / Discrete GPU
+//
+bool Spout::GetPreferredAdapterName(int preference, char* adaptername, int maxchars)
+{
+	return spoutdx.GetPreferredAdapterName(preference, adaptername, maxchars);
+}
+
+//---------------------------------------------------------
+// Function: SetPreferredAdapter
+//
+// Set graphics adapter index for a Windows preference
+//
+// This index is used by CreateDX11device when DirectX is intitialized
+//
+//    DXGI_GPU_PREFERENCE_UNSPECIFIED - (0) Equivalent to EnumAdapters1
+//
+//    DXGI_GPU_PREFERENCE_MINIMUM_POWER - (1) Integrated GPU
+//
+//    DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE - (2) External GPU / Discrete GPU
+//
+bool Spout::SetPreferredAdapter(int preference)
+{
+	return spoutdx.SetPreferredAdapter(preference);
+}
+
+//---------------------------------------------------------
+// Function: IsPreferenceAvailable()
+// Availability of Windows graphics preference settings.
+//
+bool Spout::IsPreferenceAvailable()
+{
+	return spoutdx.IsPreferenceAvailable();
+}
+
+//---------------------------------------------------------
+// Function: IsApplicationPath
+//
+// Is the path a valid application
+//
+// A valid application path will have a drive letter and terminate with ".exe"
+bool Spout::IsApplicationPath(const char* path)
+{
+	if (!path)
+		return false;
+
+	return spoutdx.IsApplicationPath(path);
+}
+#endif
+
+
+//
+// Group: 2.006 compatibility
+//
+// These functions are not necessary for Version 2.007
+// and should not be used for a new application.
+// They are retained for compatibility with existing 2.006 code
+// and may be removed in future release.
+// For full compatibility with exsiting 2.006 code, the original
+// 2.006 SDK is preserved in a <separate branch. at https://github.com/leadedge/Spout2/tree/2.006>
+//
+
+//---------------------------------------------------------
+// Function: FindNVIDIA
+// Find the index of the NVIDIA adapter in a multi-adapter system
+bool Spout::FindNVIDIA(int &nAdapter)
+{
+	return spoutdx.FindNVIDIA(nAdapter);
+}
+
+//---------------------------------------------------------
+// Function: GetAdapterInfo
+// Get detailed information for the current graphics adapter
+// Must be called after DirectX initialization, not before
+//
+// NOTES : On a “normal” system the Windows function EnumDisplayDevices and the DirectX function
+// IDXGIAdapter::GetDesc always concur. i.e. the device that owns the head will be the device that
+// performs the rendering. 
+//
+// On an Optimus system IDXGIAdapter::GetDesc will return whichever device has been selected for rendering.
+// So on an Optimus system it is possible that IDXGIAdapter::GetDesc will return the dGPU whereas 
+// EnumDisplayDevices will return the iGPU.
+//
+// This function compares the adapter descriptions of the two
+// The string "Intel" reveals that it is an Intel device but 
+// the Vendor ID could also be used. For example :
+//	- 0x10DE NVIDIA
+//	- 0x163C Intel
+//	- 0x8086 Intel
+//	- 0x8087 Intel
+//
+// See also the DirectX only version :
+// bool spoutDirectX::GetAdapterInfo(char *adapter, char *display, int maxchars)
+// DirectX9 not supported
+//
+bool Spout::GetAdapterInfo(char* renderadapter,
+	char* renderdescription, char* renderversion,
+	char* displaydescription, char* displayversion,
+	int maxsize)
+{
+	if(!renderadapter
+	|| !renderdescription
+	|| !renderversion
+	|| !displaydescription
+	|| !displayversion)
+		return false;
+
+	IDXGIDevice * pDXGIDevice = nullptr;
+
+	*renderadapter = 0; // DirectX adapter
+	*renderdescription = 0;
+	*renderversion = 0;
+	*displaydescription = 0;
+	*displayversion = 0;
+
+	if (!spoutdx.GetDX11Device()) {
+		SpoutLogError("Spout::GetAdapterInfo - no DX11 device");
+		return false;
+	}
+
+	spoutdx.GetDX11Device()->QueryInterface(__uuidof(IDXGIDevice), (void**)(&pDXGIDevice));
+	if (!pDXGIDevice) return false;
+
+	IDXGIAdapter * pDXGIAdapter = nullptr;
+	pDXGIDevice->GetAdapter(&pDXGIAdapter);
+	if (!pDXGIAdapter) return false;
+
+	DXGI_ADAPTER_DESC adapterinfo;
+	pDXGIAdapter->GetDesc(&adapterinfo);
+
+	// WCHAR Description[ 128 ];
+	// UINT VendorId;
+	// UINT DeviceId;
+	// UINT SubSysId;
+	// UINT Revision;
+	// SIZE_T DedicatedVideoMemory;
+	// SIZE_T DedicatedSystemMemory;
+	// SIZE_T SharedSystemMemory;
+	// LUID AdapterLuid;
+	char output[256]={};
+	size_t charsConverted = 0;
+	wcstombs_s(&charsConverted, output, 129, adapterinfo.Description, 128);
+	// printf("    Description = [%s]\n", output);
+	// printf("    VendorId = [%d] [%x]\n", adapterinfo.VendorId, adapterinfo.VendorId);
+	// printf("SubSysId = [%d] [%x]\n", adapterinfo.SubSysId, adapterinfo.SubSysId);
+	// printf("DeviceId = [%d] [%x]\n", adapterinfo.DeviceId, adapterinfo.DeviceId);
+	// printf("Revision = [%d] [%x]\n", adapterinfo.Revision, adapterinfo.Revision);
+	strcpy_s(renderadapter, maxsize, output);
+	if (!*renderadapter) return false;
+
+	strcpy_s(renderdescription, maxsize, renderadapter);
+
+	//
+	// Use Windows functions to look for Intel graphics to see if it is
+	// the same render adapter that was detected with DirectX
+	//
+	char driverdescription[256]={};
+	char driverversion[256]={};
+	char regkey[256]={};
+
+	// Additional info
+	DISPLAY_DEVICE DisplayDevice;
+	DisplayDevice.cb = sizeof(DISPLAY_DEVICE);
+
+	// Detect the adapter attached to the desktop.
+	//
+	// To select all display devices in the desktop, use only the display devices
+	// that have the DISPLAY_DEVICE_ATTACHED_TO_DESKTOP flag in the DISPLAY_DEVICE structure.
+	int nDevices = 0;
+	for (DWORD i = 0; i < 10; i++) { // should be much less than 10 adapters
+		if (EnumDisplayDevices(NULL, i, &DisplayDevice, 0)) {
+			// This will list all the devices
+			nDevices++;
+			// Get the registry key
+			wcstombs_s(&charsConverted, regkey, 129, (const wchar_t *)DisplayDevice.DeviceKey, 128);
+			// This is the registry key with all the information about the adapter
+			OpenDeviceKey(regkey, 256, driverdescription, driverversion);
+			if (!driverdescription || !driverversion) {
+				pDXGIDevice->Release();
+				return false;
+			}
+
+			// Is it a render adapter ?
+			if (renderadapter && strcmp(driverdescription, renderadapter) == 0) {
+				strcpy_s(renderdescription, maxsize, driverdescription);
+				strcpy_s(renderversion, maxsize, driverversion);
+			}
+
+			// Is it a display adapter
+			if (DisplayDevice.StateFlags & DISPLAY_DEVICE_ATTACHED_TO_DESKTOP) {
+				strcpy_s(displaydescription, 256, driverdescription);
+				strcpy_s(displayversion, 256, driverversion);
+			} // endif attached to desktop
+
+		} // endif EnumDisplayDevices
+	} // end search loop
+
+	pDXGIDevice->Release();
+
+	// The render adapter description
+	trim(renderdescription);
+
+	// The display adapter description
+	trim(renderdescription);
+
+	return true;
+}
+
+//---------------------------------------------------------
+// Function: CreateSender
+// Create a sender
+bool Spout::CreateSender(const char* name, unsigned int width, unsigned int height, DWORD dwFormat)
+{
+	if (!name)
+		return false;
+
+	// Pass on to CheckSender
+	SetSenderName(name);
+	if (dwFormat > 0)
+		m_dwFormat = dwFormat;
+
+	return CheckSender(width, height);
+
+}
+
+//---------------------------------------------------------
+// Function: UpdateSender
+// Update a sender
+bool Spout::UpdateSender(const char* name, unsigned int width, unsigned int height)
+{
+	if (!name)
+		return false;
+
+	// No update unless already created
+	if (!IsInitialized()) {
+		return false;
+	}
+
+	// For a name change, close the sender and set up again
+	if (strcmp(name, m_SenderName) != 0)
+		ReleaseSender();
+
+	// CheckSender sets m_Width and m_Height on success
+	return CheckSender(width, height);
+}
+
+//---------------------------------------------------------
+// Function: CreateReceiver
+// Create receiver connection
+bool Spout::CreateReceiver(char* sendername, unsigned int &width, unsigned int &height)
+{
+	if (!sendername)
+		return false;
+
+	if (!OpenSpout())
+		return false;
+	
+	if (ReceiveSenderData()) {
+		// The sender name, width, height, format, shared texture handle
+		// and shared texture pointer have been retrieved.
+		if (m_bUpdated) {
+			// If the sender is new or changed, create or re-create interop
+			if (m_bTextureShare) {
+				// Flag "true" for receive
+				if (!CreateInterop(m_Width, m_Height, m_dwFormat, true)) {
+					return false;
+				}
+			}
+			// 2.006 receivers check for changed sender size
+			m_bUpdated = false;
+		}
+		strcpy_s(sendername, 256, m_SenderName);
+		width = m_Width;
+		height = m_Height;
+
+		return true;
+	}
+
+	return false;
+
+}
+
+//---------------------------------------------------------
+// Function: CheckReceiver
+// Check receiver connection
+bool Spout::CheckReceiver(char* name, unsigned int &width, unsigned int &height, bool &bConnected)
+{
+	if (!name)
+		return false;
+
+	if (ReceiveSenderData()) {
+		strcpy_s(name, 256, m_SenderName);
+		width = m_Width;
+		height = m_Height;
+		bConnected = m_bConnected;
+		return true;
+	}
+	return false;
+}
+
+//---------------------------------------------------------
+// Function: ReceiveTexture
+// Receive OpenGL texture
+bool Spout::ReceiveTexture(char* name, unsigned int &width, unsigned int &height,
+	GLuint TextureID, GLuint TextureTarget, bool bInvert, GLuint HostFBO)
+{
+	if (!name)
+		return false;
+
+	if (ReceiveTexture(TextureID, TextureTarget, bInvert, HostFBO)) {
+
+		// 2.006 receivers have to restart for a new sender name
+		if (m_SenderName[0] && strcmp(m_SenderName, name) != 0) {
+			return false;
+		}
+
+		strcpy_s(name, 256, m_SenderName);
+		width = m_Width;
+		height = m_Height;
+		return true;
+	}
+
+	return false;
+
+}
+
+//---------------------------------------------------------
+// Function: ReceiveImage
+// Receive image pixels
+// Format can be GL_RGBA, GL_BGRA, GL_RGB or GL_BGR for the receving buffer
+bool Spout::ReceiveImage(unsigned char* pixels, GLenum glFormat, bool bInvert, GLuint HostFbo)
+{
+	// The receiving pixel buffer is created after the first update
+	// so the pixel pointer can be NULL here
+
+	// Return if flagged for update
+	// The update flag is reset when the receiving application calls IsUpdated()
+	if (m_bUpdated) {
+		return true;
+	}
+
+	// Make sure OpenGL and DirectX are initialized
+	if (!OpenSpout()) {
+		return false;
+	}
+
+	// Check for BGRA support
+	GLenum glformat = glFormat;
+	if (!m_bBGRAavailable) {
+		// If the bgra extensions are not available and the user
+		// provided GL_BGR_EXT or GL_BGRA_EXT do not use them
+		if (glFormat == GL_BGR_EXT) glformat = GL_RGB; // GL_BGR_EXT
+		if (glFormat == GL_BGRA_EXT) glformat = GL_RGBA; // GL_BGRA_EXT
+	}
+
+	// Try to receive texture details from a sender
+	if (ReceiveSenderData()) {
+
+		// The sender name, width, height, format, shared texture handle and pointer have been retrieved.
+		// m_Width, m_Height, m_dwFormat are updated
+		if (m_bUpdated) {
+
+			// If the sender is new or changed, return to update the receiving texture.
+			// The application detects the change with IsUpdated().
+			if (m_bTextureShare) {
+				// Flag "true" for receive
+				if (!CreateInterop(m_Width, m_Height, m_dwFormat, true)) {
+					return false;
+				}
+			}
+			return true;
+		}
+
+		// The receiving pixel buffer is created after the first update
+		// So check here instead of at the beginning
+		if (!pixels) {
+			return false;
+		}
+
+		//
+		// Found a sender
+		//
+		// Read the shared texture into the pixel buffer
+		// Copy functions handle the formats supported
+		//
+
+		// Was the sender's shared texture handle null ?
+		if (!m_dxShareHandle || m_bMemoryShare) {
+			// Possible existence of sender memory share map
+			// Currently only works for Texture share mode
+			if (m_bTextureShare) {
+				ReadMemoryPixels(m_SenderName, pixels, m_Width, m_Height, glFormat, bInvert);
+			}
+		}
+		else if (m_bTextureShare) {
+			// Texture share compatible
+			// Read pixels using OpenGL via PBO
+			// PBO (UnloadTexturePixels)
+			// 1920x1080 RGB 1.4 msec/frame RGBA 1.6 msec/frame
+			// 3840x2160 RGB 5 msec/frame RGBA 6 msec/frame
+			// FBO (ReadTextureData) - slower than DirectX method
+			// (3840x2160 RGB 30-60 msec/frame RGBA 30-60 msec/frame)
+			ReadGLDXpixels(pixels, m_Width, m_Height, glformat, bInvert, HostFbo);
+		}
+		else if (m_bCPUshare) {
+			// Auto share enabled for DirectX CPU backup
+			// Read pixels via DX11 staging textures to an rgba or rgb buffer
+			// 1920x1080 RGB 7 msec/frame RGBA 2 msec/frame
+			// 3840x2160 RGB 30 msec/frame RGBA 9 msec/frame
+			ReadDX11pixels(pixels, m_Width, m_Height, glformat, bInvert);
+		}
+
+		m_bConnected = true;
+	} // sender exists
+	else {
+		// There is no sender or the connected sender closed.
+		ReleaseReceiver();
+		// Let the application know.
+		m_bConnected = false;
+	}
+
+	// ReceiveImage fails if there is no sender or the connected sender closed.
+	return m_bConnected;
+
+} // end ReceiveImage
+
+
+//---------------------------------------------------------
+// Function: SelectSenderPanel
+// Open dialog for the user to select a sender
+//
+//  Optional message argument
+//
+// Replaced by SelectSender for 2.007
+//
+bool Spout::SelectSenderPanel(const char* message)
+{
+	HANDLE hMutex1 = NULL;
+	HMODULE module = NULL;
+	char path[MAX_PATH]={};
+	char drive[MAX_PATH]={};
+	char dir[MAX_PATH]={};
+	char fname[MAX_PATH]={};
+	char UserMessage[512]={};
+
+	if (message && *message) {
+		strcpy_s(UserMessage, 512, message); // could be an arg or a user message
+	}
+	else {
+		// Send the receiver graphics adapter index by default
+		strcpy_s(UserMessage, MAX_PATH, std::to_string(GetAdapter()).c_str());
+	}
+
+	// The selected sender is then the "Active" sender and this receiver switches to it.
+	// If Spout is not installed, SpoutPanel.exe has to be in the same folder
+	// as this executable. This rather complicated process avoids having to use a dialog
+	// which causes problems with host GUI messaging.
+
+	// First find if there has been a Spout installation >= 2.002 with an install path for SpoutPanel.exe
+	path[0] = 0;
+	if (!ReadPathFromRegistry(HKEY_CURRENT_USER, "Software\\Leading Edge\\SpoutPanel", "InstallPath", path)) {
+		// Path not registered so find the path of the host program
+		// where SpoutPanel should have been copied
+		module = GetModuleHandle(NULL);
+		GetModuleFileNameA(module, path, MAX_PATH);
+		_splitpath_s(path, drive, MAX_PATH, dir, MAX_PATH, fname, MAX_PATH, NULL, 0);
+		_makepath_s(path, MAX_PATH, drive, dir, "SpoutPanel", ".exe");
+	}
+
+	if (path[0]) {
+		// Does SpoutPanel.exe exist in this path ?
+		if(_access(path, 0) == -1) {
+			// Try the current working directory
+			if (_getcwd(path, MAX_PATH)) {
+				strcat_s(path, MAX_PATH, "\\SpoutPanel.exe");
+				// Does SpoutPanel exist here?
+				if (_access(path, 0) == -1) {
+					return false;
+				}
+			}
+		}
+	}
+
+	// Check whether the panel is already running
+	// Try to open the application mutex.
+	hMutex1 = OpenMutexA(MUTEX_ALL_ACCESS, 0, "SpoutPanel");
+	if (!hMutex1) {
+		// No mutex, so not running, so can open it
+		// Use ShellExecuteEx so we can test its return value later
+		ZeroMemory(&m_ShExecInfo, sizeof(m_ShExecInfo));
+		m_ShExecInfo.cbSize = sizeof(SHELLEXECUTEINFO);
+		m_ShExecInfo.fMask = SEE_MASK_NOCLOSEPROCESS;
+		m_ShExecInfo.hwnd = NULL;
+		m_ShExecInfo.lpVerb = NULL;
+		m_ShExecInfo.lpFile = (LPCSTR)path;
+		m_ShExecInfo.lpParameters = UserMessage;
+		m_ShExecInfo.lpDirectory = NULL;
+		m_ShExecInfo.nShow = SW_SHOW;
+		m_ShExecInfo.hInstApp = NULL;
+		ShellExecuteExA(&m_ShExecInfo);
+		//
+		// The flag "m_bSpoutPanelOpened" is set here to indicate that the user
+		// has opened the panel to select a sender. This flag is local to 
+		// this process so will not affect any other receiver instance
+		// Then when the selection panel closes, sender name is tested
+		//
+		m_bSpoutPanelOpened = true;
+
+	}
+	else {
+		// The mutex exists, so another instance is already running.
+		// Find the SpoutPanel window and bring it to the top.
+		// SpoutPanel is opened as topmost anyway but pop it to
+		// the front in case anything else has stolen topmost.
+		HWND hWnd = FindWindowA(NULL, (LPCSTR)"SpoutPanel");
+		if (hWnd && IsWindow(hWnd)) {
+			SetForegroundWindow(hWnd);
+			// prevent other windows from hiding the dialog
+			// and open the window wherever the user clicked
+			SetWindowPos(hWnd, HWND_TOPMOST, 0, 0, 0, 0, SWP_ASYNCWINDOWPOS | SWP_SHOWWINDOW | SWP_NOSIZE | SWP_NOMOVE);
+		}
+		else if (path[0]) {
+			// If the window was not found but the mutex exists
+			// and SpoutPanel is installed, it has crashed.
+			// Terminate the process and the mutex or the mutex will remain
+			// and SpoutPanel will not be started again.
+			PROCESSENTRY32 pEntry{};
+			pEntry.dwSize = sizeof(pEntry);
+			bool done = false;
+			// Take a snapshot of all processes and threads in the system
+			HANDLE hProcessSnap = CreateToolhelp32Snapshot(TH32CS_SNAPALL, NULL);
+			if (hProcessSnap == INVALID_HANDLE_VALUE) {
+				SpoutLogError("spoutDX::OpenSpoutPanel - CreateToolhelp32Snapshot error");
+			}
+			else {
+				// Retrieve information about the first process
+				BOOL hRes = Process32First(hProcessSnap, &pEntry);
+				if (!hRes) {
+					SpoutLogError("spoutDX::OpenSpoutPanel - Process32First error");
+					CloseHandle(hProcessSnap);
+				}
+				else {
+					// Look through all processes to find SpoutPanel
+					while (hRes && !done) {
+#ifdef UNICODE
+						_wcsicmp(pEntry.szExeFile, L"SpoutPanel.exe");
+#else
+						_tcsicmp(pEntry.szExeFile, _T("SpoutPanel.exe"));
+#endif
+						HANDLE hProcess = OpenProcess(PROCESS_TERMINATE, 0, pEntry.th32ProcessID);
+						if (hProcess != NULL) {
+							// Terminate SpoutPanel and it's mutex if it opened
+							TerminateProcess(hProcess, 9);
+							CloseHandle(hProcess);
+							done = true;
+						}
+
+						if (!done)
+							hRes = Process32Next(hProcessSnap, &pEntry); // Get the next process
+						else
+							hRes = NULL; // found SpoutPanel
+					}
+					CloseHandle(hProcessSnap);
+				}
+			}
+			// Now SpoutPanel will start the next time the user activates it
+		} // endif SpoutPanel crashed
+	} // endif SpoutPanel already open
+
+	// If we opened the mutex, close it now or it is never released
+	if (hMutex1) CloseHandle(hMutex1);
+
+	return true;
+
+} // end SelectSenderPanel
+
+//
+// Group: Legacy OpenGL Draw functions
+//
+// These functions are retained for compatibility with existing 2.006 code.
+//
+// Enabled for build with "legacyOpenGL" defined in SpoutCommon.h
+//
+#ifdef legacyOpenGL
+
+//---------------------------------------------------------
+// Function: DrawSharedTexture
+// Render the sender shared OpenGL texture
+bool Spout::DrawSharedTexture(float max_x, float max_y, float aspect, bool bInvert, GLuint HostFBO)
+{
+	UNREFERENCED_PARAMETER(HostFBO);
+	if (!m_hInteropDevice || !m_hInteropObject)
+		return false;
+
+	bool bRet = false;
+
+	// Wait for access to the shared texture
+	if (frame.CheckTextureAccess(m_pSharedTexture)) {
+		// go ahead and access the shared texture to draw it
+		if (LockInteropObject(m_hInteropDevice, &m_hInteropObject) == S_OK) {
+			SaveOpenGLstate(m_Width, m_Height);
+			glEnable(GL_TEXTURE_2D);
+			glBindTexture(GL_TEXTURE_2D, m_glTexture); // bind shared texture
+			glColor4f(1.f, 1.f, 1.f, 1.f);
+			// Tried to convert to vertex array, but Processing crash
+			glBegin(GL_QUADS);
+			if (bInvert) {
+				glTexCoord2f(0.0, max_y);	glVertex2f(-aspect, -1.0); // lower left
+				glTexCoord2f(0.0, 0.0);		glVertex2f(-aspect,  1.0); // upper left
+				glTexCoord2f(max_x, 0.0);	glVertex2f( aspect,  1.0); // upper right
+				glTexCoord2f(max_x, max_y);	glVertex2f( aspect, -1.0); // lower right
+			}
+			else {
+				glTexCoord2f(0.0, 0.0);		glVertex2f(-aspect, -1.0); // lower left
+				glTexCoord2f(0.0, max_y);	glVertex2f(-aspect,  1.0); // upper left
+				glTexCoord2f(max_x, max_y);	glVertex2f( aspect,  1.0); // upper right
+				glTexCoord2f(max_x, 0.0);	glVertex2f( aspect, -1.0); // lower right
+			}
+			glEnd();
+			glBindTexture(GL_TEXTURE_2D, 0);
+			glDisable(GL_TEXTURE_2D);
+			RestoreOpenGLstate();
+			UnlockInteropObject(m_hInteropDevice, &m_hInteropObject); // unlock dx object
+			bRet = true;
+		} // lock failed
+		// Release mutex and allow access to the texture
+		frame.AllowTextureAccess(m_pSharedTexture);
+	} // mutex lock failed
+
+	return bRet;
+
+} // end DrawSharedTexture
+
+//---------------------------------------------------------
+// Function: DrawToSharedTexture
+// Render OpenGL texture to the sender shared OpenGL texture.
+bool Spout::DrawToSharedTexture(GLuint TextureID, GLuint TextureTarget,
+	unsigned int width, unsigned int height,
+	float max_x, float max_y, float aspect,
+	bool bInvert, GLuint HostFBO)
+{
+	GLenum status;
+	bool bRet = false;
+
+	if (!m_hInteropDevice || !m_hInteropObject)
+		return false;
+
+	if (width != (unsigned  int)m_Width || height != (unsigned  int)m_Height)
+		return false;
+
+	// Wait for access to the shared texture
+	if (frame.CheckTextureAccess(m_pSharedTexture)) {
+		if (LockInteropObject(m_hInteropDevice, &m_hInteropObject) == S_OK) {
+			// Draw the input texture into the shared texture via an fbo
+			// Bind our fbo and attach the shared texture to it
+			glBindFramebufferEXT(GL_FRAMEBUFFER_EXT, m_fbo);
+			glClearColor(0.f, 0.f, 0.f, 1.f);
+			glClear(GL_COLOR_BUFFER_BIT);
+			glFramebufferTexture2DEXT(GL_READ_FRAMEBUFFER_EXT, GL_COLOR_ATTACHMENT0_EXT, GL_TEXTURE_2D, m_glTexture, 0);
+			status = glCheckFramebufferStatusEXT(GL_FRAMEBUFFER_EXT);
+			if (status == GL_FRAMEBUFFER_COMPLETE_EXT) {
+				glColor4f(1.f, 1.f, 1.f, 1.f);
+				glEnable(TextureTarget);
+				glBindTexture(TextureTarget, TextureID);
+				GLfloat tc[4][2] = { 0 };
+				// Invert texture coord to user requirements
+				if (bInvert) {
+					tc[0][0] = 0.0;   tc[0][1] = max_y;
+					tc[1][0] = 0.0;   tc[1][1] = 0.0;
+					tc[2][0] = max_x; tc[2][1] = 0.0;
+					tc[3][0] = max_x; tc[3][1] = max_y;
+				}
+				else {
+					tc[0][0] = 0.0;   tc[0][1] = 0.0;
+					tc[1][0] = 0.0;   tc[1][1] = max_y;
+					tc[2][0] = max_x; tc[2][1] = max_y;
+					tc[3][0] = max_x; tc[3][1] = 0.0;
+				}
+				GLfloat verts[] = {
+								-aspect, -1.0,   // bottom left
+								-aspect,  1.0,   // top left
+								 aspect,  1.0,   // top right
+								 aspect, -1.0 }; // bottom right
+				glEnableClientState(GL_TEXTURE_COORD_ARRAY);
+				glTexCoordPointer(2, GL_FLOAT, 0, tc);
+				glEnableClientState(GL_VERTEX_ARRAY);
+				glVertexPointer(2, GL_FLOAT, 0, verts);
+				glDrawArrays(GL_TRIANGLE_FAN, 0, 4);
+				glDisableClientState(GL_VERTEX_ARRAY);
+				glDisableClientState(GL_TEXTURE_COORD_ARRAY);
+				glBindTexture(TextureTarget, 0);
+				glDisable(TextureTarget);
+				bRet = true; // success
+			}
+			else {
+				PrintFBOstatus(status);
+				glBindFramebufferEXT(GL_FRAMEBUFFER_EXT, HostFBO);
+				UnlockInteropObject(m_hInteropDevice, &m_hInteropObject);
+			}
+			// restore the previous fbo - default is 0
+			glBindFramebufferEXT(GL_FRAMEBUFFER_EXT, HostFBO);
+			UnlockInteropObject(m_hInteropDevice, &m_hInteropObject);
+		} // end interop lock
+		// Release mutex and allow access to the texture
+		frame.AllowTextureAccess(m_pSharedTexture);
+	} // mutex access failed
+
+	return bRet;
+
+} // end DrawToSharedTexture
+#endif
+
+//
+// Protected functions
+//
+
+//---------------------------------------------------------
+// If a sender has not been created yet
+//    o Make sure Spout has been initialized and OpenGL context is available
+//    o Perform a compatibility check for GL/DX interop
+//    o If compatible, create interop for GL/DX transfer
+//    o If not compatible, create a shared texture for the sender
+//    o Create a sender using the DX11 shared texture handle
+// If the sender exists, test for size change
+//    o If compatible, update the shared textures and GL/DX interop
+//    o If not compatible, re-create the class shared texture to the new size
+//    o Update the sender and class variables	
+bool Spout::CheckSender(unsigned int width, unsigned int height)
+{
+	if (width == 0 || height == 0) {
+		return false;
+	}
+
+	// The sender needs a name. Default is the executable name
+	// If a sender with this name is already registered,
+	// SetSenderName increments the name : sender_1, sender_2 etc.
+	if (!m_SenderName[0]) {
+		SetSenderName();
+	}
+
+	// If not initialized, create a new sender
+	if (!m_bInitialized) {
+
+		// Make sure that Spout has been initialized and an OpenGL context is available
+		if (!OpenSpout())
+			return false;
+
+		if (m_bTextureShare) {
+			// Create interop for GL/DX transfer
+			// Flag "false" for sender so that a new shared texture and handle are created.
+			// For a receiver the shared texture is created from the sender share handle.
+			if (!CreateInterop(width, height, m_dwFormat, false)) {
+				SpoutLogWarning("Spout::CheckSender(%s, %dx%d) - create - CreateInterop failed", m_SenderName, width, height);
+				return false;
+			}
+		}
+		else {
+			// For CPU share with DirectX textures.
+			// A sender creates a new shared texture within this class with a new share handle
+			m_dxShareHandle = nullptr;
+			if (!spoutdx.CreateSharedDX11Texture(spoutdx.GetDX11Device(),
+				width, height, (DXGI_FORMAT)m_dwFormat, &m_pSharedTexture, m_dxShareHandle)) {
+				SpoutLogWarning("Spout::CheckSender(%s, %dx%d) - create cpu - CreateSharedDX11Texture failed", m_SenderName, width, height);
+				return false;
+			}
+		}
+
+		// Create a sender using the DX11 shared texture handle (m_dxShareHandle)
+		// If the sender already exists, the name is incremented
+		// name, name_1, name_2 etc
+		if (sendernames.CreateSender(m_SenderName, width, height, m_dxShareHandle, m_dwFormat)) {
+
+			m_Width = width;
+			m_Height = height;
+
+			//
+			// SetSenderID writes to the sender shared texture memory
+			// to set sender CPU sharing mode and hardware GL/DX compatibility
+			//
+			// Using CPU sharing methods (m_bCPUshare) - set top bit
+			// 1000 0000 0000 0000 0000 0000 0000 0000
+			//
+			// GL/DX compatible hardware (m_bUseGLDX) - set next to top bit
+			// 0100 0000 0000 0000 0000 0000 0000 0000
+			//
+			// Both bits can be set if GL/DX compatible but the user has selected CPU share mode
+			//
+			SetSenderID(m_SenderName, m_bCPUshare, m_bUseGLDX);
+
+			m_Width = width;
+			m_Height = height;
+
+			// Create a sender mutex for access to the shared texture
+			frame.CreateAccessMutex(m_SenderName);
+
+			// Enable frame counting so the receiver gets frame number and fps
+			frame.EnableFrameCount(m_SenderName);
+
+			m_bInitialized = true;
+		}
+		else {
+			SpoutLogWarning("Spout::CheckSender(%s, %dx%d) - create - CreateSender failed", m_SenderName, width, height);
+			ReleaseSender();
+			m_SenderName[0] = 0;
+			m_Width = 0;
+			m_Height = 0;
+			m_dwFormat = m_DX11format;
+			return false;
+		}
+	}
+	// The sender is initialized but has the sending texture changed size ?
+	else if (m_Width != width || m_Height != height) {
+
+		// Update the shared textures and interop
+		if (m_bTextureShare) {
+			// The linked textures cannot be re-sized so have to 
+			// be re-created. The interop object handle is then
+			// re-created from the linking of the new textures.
+			// Flag "false" for sender to create a new shared texture.
+			// Release interop device/object and OpenGL objects and re-create
+			CleanupInterop();
+			CleanupGL();
+			if (!CreateInterop(width, height, m_dwFormat, false)) {
+				SpoutLogWarning("Spout::CheckSender(%s, %dx%d) - update CreateInterop failed", m_SenderName, width, height);
+				return false;
+			}
+		}
+		else {
+			// For CPU share, the DirectX texture is not linked to OpenGL
+			// Re-create the class shared texture to the new size
+			if (m_pSharedTexture)
+				spoutdx.ReleaseDX11Texture(GetDX11Device(), m_pSharedTexture);
+			m_pSharedTexture = nullptr;
+			m_dxShareHandle = nullptr;
+
+			// Flush context to avoid deferred release
+			spoutdx.Flush();
+
+			if (!spoutdx.CreateSharedDX11Texture(spoutdx.GetDX11Device(),
+				width, height, (DXGI_FORMAT)m_dwFormat, &m_pSharedTexture, m_dxShareHandle)) {
+				SpoutLogWarning("Spout::CheckSender(%s, %dx%d) - cpu - CreateSharedDX11Texture failed", m_SenderName, width, height);
+				return false;
+			}
+		}
+
+		// Update the sender with the new texture and size
+		if (!sendernames.UpdateSender(m_SenderName, width, height, m_dxShareHandle, m_dwFormat)) {
+			SpoutLogWarning("Spout::CheckSender(%s, %dx%d) - UpdateSender failed", m_SenderName, width, height);
+			ReleaseSender();
+			m_SenderName[0] = 0;
+			m_Width = 0;
+			m_Height = 0;
+			m_dwFormat = m_DX11format;
+			return false;
+		}
+
+		m_Width = width;
+		m_Height = height;
+	}
+
+	// endif initialization or size checks
+
+	return true;
+}
+
+
+//---------------------------------------------------------
+void Spout::InitReceiver(const char * SenderName, unsigned int width, unsigned int height, DWORD dwFormat)
+{
+	if (!SenderName)
+		return;
+
+	SpoutLogNotice("Spout::InitReceiver(%s, %dx%d)", SenderName, width, height);
+
+	// Create a named sender mutex for access to the sender's shared texture
+	frame.CreateAccessMutex(SenderName);
+
+	// Enable frame counting to get the sender frame number and fps
+	frame.EnableFrameCount(SenderName);
+
+	// Set class globals
+	strcpy_s(m_SenderName, 256, SenderName);
+
+	m_Width = width;
+	m_Height = height;
+	m_dwFormat = dwFormat;
+	m_DX11format = (DXGI_FORMAT)m_dwFormat;
+
+	m_bInitialized = true;
+
+}
+
+//---------------------------------------------------------
+bool Spout::ReceiveSenderData()
+{
+	m_bUpdated = false;
+
+	// Initialization is recorded in this class for sender or receiver
+	// m_Width or m_Height are established when the receiver connects to a sender
+
+	// An existing connection will have a sender name
+	// Or a name may be set for the receiver to connect to
+	char sendername[256]={};
+	strcpy_s(sendername, 256, m_SenderName);
+
+	// Find the active sender if the global sender name is null
+	if (sendername[0] == 0) {
+		if (!GetActiveSender(sendername)) {
+			return false; // No sender
+		}
+	}
+
+	// If SpoutPanel or SpoutMessgeBox have been opened and a 
+	// sender selected, the active sender name could be different.
+	// Retrieve the new name but do not clear the receiver setup name.
+	CheckSpoutPanel(sendername, 256);
+
+	// Now we have either an existing sender name or the active sender name
+	// Save current sender name and dimensions to test for change
+	unsigned int width = m_Width;
+	unsigned int height = m_Height;
+	DWORD dwFormat = m_dwFormat;
+	HANDLE dxShareHandle = m_dxShareHandle;
+
+	// Retrieve the sender information : width, height, sharehandle and format.
+	SharedTextureInfo info;
+	if (sendernames.getSharedInfo(sendername, &info)) {
+
+		width = info.width;
+		height = info.height;
+		dxShareHandle = UIntToPtr(info.shareHandle);
+		dwFormat = info.format;
+
+		//
+		// The following flags are informative only
+		// and may be removed in future release
+		//
+		// GPU texture share and hardware GL/DX compatible by default
+		m_bSenderCPU  = false;
+		m_bSenderGLDX = true;
+
+		//
+		// 32 bit partner ID field
+		//
+
+		// Top bit only
+		//   o Sender is using CPU share methods
+		//   o Hardware GL/DX compatibility undefined - assume false
+		if (info.partnerId == 0x80000000) {
+			m_bSenderCPU = true;
+			m_bSenderGLDX = false;
+		}
+
+		//
+		// Next top bit only (top bit not set)
+		//   o Sender hardware is GL/DX compatible
+		//   o Using texture share methods
+		if (info.partnerId == 0x40000000) {
+			m_bSenderCPU = false;
+			m_bSenderGLDX = true;
+		}
+
+		//
+		// Both bits set (and none other)
+		//   o Sender is using CPU share methods
+		//   o Sender hardware is GL/DX compatible
+		if (info.partnerId == 0xC0000000) {
+			m_bSenderCPU = true;
+			m_bSenderGLDX = true;
+		}
+
+		// Compatible DX9 formats
+		// 21 =	D3DFMT_A8R8G8B8
+		// 22 = D3DFMT_X8R8G8B8
+		if (dwFormat == 21 || dwFormat == 22) {
+			// Create a DX11 receiving texture with compatible format
+			dwFormat = DXGI_FORMAT_B8G8R8A8_UNORM;
+		}
+
+
+		// The shared texture handle will be different
+		//   o for texture size or format change
+		//   o for a new sender
+		// Open the sender share handle to produce a new received texture
+		if (dxShareHandle != m_dxShareHandle || strcmp(sendername, m_SenderName) != 0) {
+
+			// Release everything to start again
+			ReleaseReceiver();
+
+			// Update the sender share handle
+			m_dxShareHandle = dxShareHandle;
+
+			// Get a new shared texture pointer from the share handle
+			if (m_dxShareHandle) {
+
+				if(spoutdx.OpenDX11shareHandle(spoutdx.GetDX11Device(), &m_pSharedTexture, dxShareHandle)) {
+
+					// Get the texture details
+					D3D11_TEXTURE2D_DESC desc={};
+					m_pSharedTexture->GetDesc(&desc);
+
+					// Check for zero size
+					if (desc.Width == 0 || desc.Height == 0) {
+						return false;
+					}
+
+					// For incorrect sender information, use dimensions and format
+					// of the D3D11 texture generated by OpenDX11shareHandle
+					if (width    != (DWORD)desc.Width)	width = (DWORD)desc.Width;
+					if (height   != (DWORD)desc.Height) height = (DWORD)desc.Height;
+					if (dwFormat != (DWORD)desc.Format) dwFormat = (DWORD)desc.Format;
+
+					// Check for texture format supported by OpenGL/DirectX interop
+					if (!(dwFormat == D3DFMT_A8R8G8B8						// 21
+						|| dwFormat == D3DFMT_X8R8G8B8						// 22
+						|| dwFormat == DXGI_FORMAT_B8G8R8X8_UNORM			// 88
+						|| dwFormat == DXGI_FORMAT_B8G8R8A8_UNORM			// 22
+						|| dwFormat == DXGI_FORMAT_R8G8B8A8_SNORM			// 31
+						|| dwFormat == DXGI_FORMAT_R8G8B8A8_UNORM			// 28
+						|| dwFormat == DXGI_FORMAT_R10G10B10A2_UNORM		// 24
+						|| dwFormat == DXGI_FORMAT_R16G16B16A16_SNORM		// 13
+						|| dwFormat == DXGI_FORMAT_R16G16B16A16_UNORM		// 11
+						|| dwFormat == DXGI_FORMAT_R8G8B8A8_UNORM_SRGB		// 29
+						|| dwFormat == DXGI_FORMAT_R16G16B16A16_FLOAT		// 10
+						|| dwFormat == DXGI_FORMAT_R32G32B32A32_FLOAT)) {	// 2
+						SpoutLogError("Spout::ReceiveSenderData - texture %dx%d incompatible texture format 0x%X (%d)",
+							width, height, dwFormat, dwFormat);
+						return false;
+					}
+
+					// If the received texture is successfully updated, initialize again
+					// with the new sender name, width, height and format
+					InitReceiver(sendername, width, height, dwFormat);
+
+					// The application can now access and copy the sender texture.
+					// Signal the application to update the receiving texture or image
+					m_bUpdated = true;
+
+				} // endif OpenDX11shareHandle succeeded
+				else {
+					//
+					// Error log generated in OpenDX11shareHandle.
+					//
+					// OpenDX11shareHandle uses OpenSharedResource, which can fail if the sender and receiver 
+					// applications are using different graphics adapters, which is possible if the user has 
+					// specified different performance preferences using Windows Display Graphics settings.
+					//
+					// Graphics performance preference is only effective for a laptop with multiple graphics.
+					// Performance settings can be accessed directly from SpoutSettings Version 1.046 and later.
+					//
+					// Do not inform the application of texture update, but retain the share handle so we don't 
+					// query the same sender again.
+					//
+					// Return true and wait until another sender is selected or the shared texture handle is valid.
+					// m_pSharedTexture is then null but make sure so that it is not used.
+					if (m_pSharedTexture) 
+						spoutdx.ReleaseDX11Texture(GetDX11Device(), m_pSharedTexture);
+					m_pSharedTexture = nullptr;
+
+				} // endif OpenDX11shareHandle fail
+
+			} // endif m_dxShareHandle valid
+			// For a null share handle from a 2.006 memoryshare sender
+			// ReceiveTexture and ReceiveImage will look for the shared memory map
+		} // endif changed share handle or sender name
+		return true;
+	} // endif find sender
+
+	// There is no sender or the connected sender closed
+	return false;
+
+}
+
+//---------------------------------------------------------
+// Check whether SpoutPanel opened and return the new sender name
+bool Spout::CheckSpoutPanel(char *sendername, int maxchars)
+{
+	if (!sendername)
+		return false;
+
+	// If SpoutPanel has been activated, test if the user has clicked OK
+	if (m_bSpoutPanelOpened) { // User has activated spout panel
+
+		char newname[256]={};
+
+		// Is SpoutPanel registered ?
+		char path[MAX_PATH]{};
+		if (!ReadPathFromRegistry(HKEY_CURRENT_USER, "Software\\Leading Edge\\SpoutPanel", "InstallPath", path)) {
+			// If not registered, SpoutMessageBox has been used
+			// Pass back the active name
+			if (sendernames.GetActiveSender(newname)) {
+				strcpy_s(sendername, maxchars, newname);
+				m_bSpoutPanelOpened = false;
+				return true;
+			}
+			return false;
+		}
+
+		//
+		// SpoutPanel
+		//
+
+		SharedTextureInfo TextureInfo = {};
+		HANDLE hMutex = NULL;
+		DWORD dwExitCode = 0;
+		bool bRet = false;
+
+		// Must find the mutex to signify that SpoutPanel has opened
+		// and then wait for the mutex to close
+		hMutex = OpenMutexA(MUTEX_ALL_ACCESS, 0, "SpoutPanel");
+
+		// Has it been activated 
+		if (!m_bSpoutPanelActive) {
+			// If the mutex has been found, set the active flag true and quit
+			// otherwise on the next round it will test for the mutex closed
+			if (hMutex) m_bSpoutPanelActive = true;
+		}
+		else if (!hMutex) { // It has now closed
+
+			m_bSpoutPanelOpened = false; // Don't do this part again
+			m_bSpoutPanelActive = false;
+			// call GetExitCodeProcess() with the hProcess member of
+			// global SHELLEXECUTEINFO to get the exit code from SpoutPanel
+			if (m_ShExecInfo.hProcess) {
+				GetExitCodeProcess(m_ShExecInfo.hProcess, &dwExitCode);
+				// Only act if exit code = 0 (OK)
+				if (dwExitCode == 0) {
+					// SpoutPanel has been activated and OK clicked
+					// Test the active sender which should have been set by SpoutPanel
+					newname[0] = 0;
+					if (!sendernames.GetActiveSender(newname)) {
+						// Otherwise the sender might not be registered.
+						// SpoutPanel always writes the selected sender name to the registry.
+						if (ReadPathFromRegistry(HKEY_CURRENT_USER, "Software\\Leading Edge\\SpoutPanel", "Sendername", newname)) {
+							// Register the sender if it exists
+							if (newname[0] != 0) {
+								if (sendernames.getSharedInfo(newname, &TextureInfo)) {
+									// If not already registered
+									if (!sendernames.FindSenderName(newname)) {
+										// Register in the list of senders and make it the active sender
+										sendernames.RegisterSenderName(newname);
+										sendernames.SetActiveSender(newname);
+									}
+								}
+							}
+						}
+					}
+
+					// Now do we have a valid sender name ?
+					if (newname[0] != 0) {
+						// Pass back the new name
+						strcpy_s(sendername, maxchars, newname);
+						bRet = true;
+					} // endif valid sender name
+				} // endif SpoutPanel OK
+			} // got the exit code
+		} // endif no mutex so SpoutPanel has closed
+		// If we opened the mutex, close it now or it is never released
+		if (hMutex) CloseHandle(hMutex);
+		return bRet;
+	} // SpoutPanel has not been opened
+
+	return false;
+
+}

--- a/libs/SpoutSDK/src/SpoutGL.cpp
+++ b/libs/SpoutSDK/src/SpoutGL.cpp
@@ -1,0 +1,4276 @@
+﻿//
+//		SpoutGL
+//
+//		Base class for OpenGL texture sharing using the NVIDIA GL/DX interop extensions
+//
+//		See also - spoutDirectX, spoutSenderNames
+//
+// ====================================================================================
+//		Revisions :
+//
+//		07.10.20	- Started class based on previous work with SpoutGLDXinterop.cpp
+//					  for 2.006 and 2.007 beta : 15-07-14 - 03-09-20
+//					  with reference to the SpoutDX class for consolidation of global variables.
+//					  Compatibility with NVIDIA GL/DX interop is tested with fall-back to CPU share
+//					  using DirectX11 staging textures for failure.
+//					  MemoryShare is supported for receive only.
+//					  DX9 support is removed.
+//		09.12.20	- Correct ReadDX11texture for staging texture pitch
+//		27.12.20	- Functions allocated to SpoutSDK class where appropriate
+//		14.01.21	- Add GetDX11Device() and GetDX11Context()
+//					  add bInvert and HostFBO options to WriteTextureReadback
+//		04.02.21	- SetHostPath and SetSenderCPUmode public
+//					  Add GetCPUshare and SetCPUshare for forced CPU share testing
+//		05.02.21	- Introduced m_bTextureShare and m_bCPUshare flags to handle mutiple options
+//		08.02.21	- WriteDX11texture, ReadTextureData, OpenSpout, LoadGLextensions cleanup
+//					  OpenSpout look for DirectX to prevent repeat
+//		26.02.21	- Change m_bSenderCPUmode to m_bSenderCPU
+//					- Add m_bSenderGLDX
+//					- Change SetSenderCPUmode to include CPU sharing mode and GLDX compatibility
+//					- Change SetSenderCPUmode name to SetSenderID
+//		13.03.21	- Add m_bMemoryShare for possible older 2.006 apps
+//					  Add memoryshare.CreateSenderMemory
+//					  memoryshare.CloseSenderMemory() in destructor
+//					  Add WriteMemoryPixels
+//					  Change ReadMemoryPixels to accept GL_LUMINANCE
+//					  Use reinterpret_cast for memoryshare.LockSenderMemory()
+//		15.03.21	- Remove m_bNewFrame
+//		20.03.21	- Add memoryshare.GetSenderMemoryName()
+//		25.03.21	- Disable frame sync in destructor
+//		02.04.21	- Change ReadMemory to ReadMemoryTexture
+//		04.04.21	- Add GetSenderMemory
+//		08.05.21	- Remove ReadMemoryBuffer open error log
+//		10.05.21	- Remove memoryshare struct from header
+//					  and replace with SpoutSharedMemory object.
+//					  Close shared memory and sync event in SpoutGL class destructor
+//		27.05.21	- Add GetMemoryBufferSize
+//		09.06.21	- Add CreateMemoryBuffer, DeleteMemoryBuffer
+//					  Revise and test data functions
+//					  All data functions return false if 2.006 memoryshare mode.
+//		26.07.21	- Remove memorysize check from GetMemoryBufferSize for receiver
+//		10.08.21	- Correct LoadGLextensions to set no PBO availabliity if FBO fails
+//					  WriteDX11texture - unmap staging texture if data read fails
+//					  ReadTextureData - allow for no FBO support for low end graphics
+//		29.09.21	- OpenSpout and LinkGLDXtextures - test for GL/DX extensions
+//		15.10.21	- Remove interop object test for repeat from OpenSpout
+//		09.11.21	- Revise UnloadTexturePixels
+//		12.11.21	- Add OpenGL context check in destructor
+//		13.11.21	- Remove code redundancy in destructor
+//					  CleanupGL, CleanupInterop - add warning logs if no context
+//					  CleanupDX11 - add warning log if no device
+//		14.11.21	- Correct ReadTextureData for RGB source
+//		16.11.21	- Remove GLerror from destructor
+//		18.11.21	- InitTexture - restore current texture binding
+//		19.11.21	- LoadGLextensions in constructor as well as OpenSpout
+//		22.11.21	- OpenSpout new line for start changed from printf to SpoutLog
+//		23.11.21	- Use SpoutDirectX ReleaseDX11Texture to release shared texture
+//		11.12.21	- OpenSpout - return false for no OpenGL context or GL extensions
+//				      Change CleanupInterop from void to bool
+//				      CleanupDX11() - test CleanupInterop before releasing textures
+//					  CleanupGL() - release interop objects before releasing shared texture
+//					  OpenDirectX and OpenDirectX11 optional device argument
+//		14.12.21	- Remove gl texture delete from GLDXready test.
+//		15.12.21	- Change no context log warning to notice in CleanupGL and CleanupDX11
+//					  LoadGLextensions - warn if pbo extensions not available or user disable
+//					  CleanupGL() - release staging textures
+//		16.12.21	- Add "No error: case comment to LinkGLDXtextures
+//					  Remove un-necessary wglDXSetResourceShareHandle from LinkGLDXtextures
+//		17.12.21	- Device argument only for OpenDirectx11
+//					  Remove wglDXSetResourceShareHandleNV from LinkGLDXtextures
+//					  Remove dxShareHandle argument from LinkGLDXtextures
+//		18.12.21	- Restore default draw for all fbo functions
+//					  Release interop objects after LinkGLDXtextures in GLDXready
+//					  Create m_bGLDXdone flag for GLDXready to avoid repeats
+//		27.12.21	- Restore default fbo in SetSharedTextureData if texture ID is zero
+//		23.01.22	- Change pointer comparision from >0 to nullptr in OpenSpout (PR #80)
+//		25.01.22	- Remove m_hInteropDevice created check in OpenSpout
+//					  Clean up logs in LoadGLextensions
+//		21.02.22	- Restore glBufferData method for in UnloadTexturePixels
+//					  Pending implementation of glFencSync for glMapBufferRange method
+//		16.03.22	- Use m_hInteropObject in LinkGLDXtextures rather than local variable
+//					  so that CleanupInterp releases the interop object
+//					- Allow for success test in GLDXReady();
+//		21.03.22	- LoadGLextensions - correct  && to & for (m_caps & GLEXT_SUPPORT_PBO)
+//					  UnloadTexturePixels - casting pitch*width for size compare avoids warning C26451
+//		29.03.22	- OpenDeviceKey - correct dwSize from MAX_PATH to 256 in RegOpenKeyExA
+//					  ReadTextureData - create unsigned long variables for temp src char array
+//					  ReadTextureData - Delete temporary "src" char array created with "new"
+//		19.04.22	- Restore host fbo in SetSharedTextureData instead of default 0
+//		04.06.22	- SetSharedTextureData - corrected glCheckFramebufferStatus from != to == for textureID 0
+//		29.07.22	- OpenSpout - default CPU share until tested
+//		28.10.22	- Documentation cleanup
+//		26.11.22	- Change SetVerticalSync argument to integer to allow adaptive vsync
+//		18.12.22	- ReadTextureData - use std::unique_ptr to create intermediate invert buffer
+//					  OpenDeviceKey use std::string "at" instead of direct index
+//					  Catch any exception by using cleanup functions in destructor
+//		19.12.22	- Add DoDiagnostics to create a log file for CreateInterop failure
+//		22.12.22	- Compiler compatibility testing
+//					  Remove std::unique_ptr and go back to new/delete
+//					  Change all {} initializations to "={}"
+//		30.12.22	- Check and confirm fix for issue #85 and PR #86
+//					  Check and confirm fix for issue #87
+//		05-01-23	- ReadGLDXtexture - Test for no texture read or zero texture
+//					  moved to the beginning to avoid redundant texture lock.
+//		06-01-23	- ReadDX11pixels check pixels arg for null
+//		08.01.23	- Option for keyed shared texture for testing
+//					  Code review - Use Microsoft Native Recommended rules
+//		18.01.23	- Remove GetSharedTextureData and replace with CopyTexture
+//		20.01.23	- changes to gl definitions in SpoutGLextensions for compatibility with Glew
+//					  SpoutGL.h - include SpoutGLextensions first to prevent gl.h before Glew.h error
+//					  GLerror gluErrorString conditional on Glew define
+//		14.04.23	- Correct CreateMemoryBuffer null name check
+// Version 2.007.011
+//		15.03.23	- If no new sender frame, return true and do not block for all receiving functions
+//					  to avoid un-necessary Acquire/Release/Lock/Unlock
+//		22.04.23	- Add compute shader utility for OpenGL texture copy
+//					  CreateInterop - delete m_glTexture before creating new
+//		04.05.23	- CopyTexture - detach textures from fbo. Blit method only for texture invert.
+//		07.05.23	- CreateOpenGL - load extensions.
+//		17.05.23	- Remove "m_bInitialized = false" check from CleanupGL and put in release functions
+//		18/05.23	- CleanupGL
+//					  Remove m_SenderName clear
+//					  Unbind textures before CleanupInterop
+//		19.05.23	- Add GetInteropObject() and GetDXsharedTexture()
+//		22.05.23	- Remove CleanupInterop from within CleanupGL and use as separate functions
+//		07.06.23	- UnloadTexturePixels - specify number of PBOs created in log
+//		09.06.23	- Use glCopyImageSubData for CopyTexture if no invert
+//		22.06.23	- CreateComputeCopyShader adjust Y workgroup number for aspect ratio
+//		03.07.23	- CreateInterop - code cleanup
+//					  ReadTextureData - change cast (#PR93)
+//		06.07.23	- Code cleanup
+//		13.07.23	- Make InitTexture public
+//		17.07.23	- CopyTexture - remove glCopyImageSubData due to format limitations
+//				      Add SwapRGB utility
+//		18.07.23	- Make GLerror() public
+//		22.07.23	- Some extra checks for null m_pSharedTexture for a receiver
+// Version 2.007.012
+//		24.07.23	- Remove  global m_bKeyed flag
+//		31.07.23	- Add OpenGL format functions
+//		04.08.23	- Remove unused compute shaders
+//		28.08.23	- UnloadTexturePixels public
+//		07.10.23	- Conditional compile options for _M_ARM64
+//		09.10.23	- Log first line indicate if ARM build
+//		19.10.23	- GLDXformat - default changed from RGBA to RGBA8
+//					  and include DXGI_FORMAT_R32G32B32_FLOAT, DXGI_FORMAT_R10G10B10A2_UNORM
+//		20.10.23	- ReadTextureData - correct glReadPixels format for RGBA data
+//					  InitTexture - add pixel type
+//					  GLFormatName - correct BGRA name
+//		01.11.23	- CreateInterop - correct uint printf formatting for error message
+//					  Avoid repeats if interop failure flag is set. Cleared by CleaunpInterop.
+//		30.11.23	- ReadMemoryTexture - remove new frame test
+//		07.12.23	- DoDiagnostics - use spoututils GetExeName
+//		08.12.23	- Remove DXGI_FORMAT_UNKNOWN from DX11format GL>DX11 conversion function
+//					  Use default DXGI_FORMAT_B8G8R8A8_UNORM
+//		14.12.23	- WriteGLDXpixels - return WriteGLDXtexture instead of true
+//					- CreateOpenGL return false if extensions fail to load
+//	Version 2.007.013
+//		26.02.24	- CreateInterop - check for dimensions out of bounds (> 16384)
+//		06.03.24	- GLerror - add error number
+//		03.04.24	- Add ReadTexturePixels for multiple format and RGB/RGBA textures
+//		08.04.24	- ReadTexturePixels - check OpenGL texture size and return if different
+//					  PrintFBOstatus - no warning if complete
+//					  InitTexture - corrected internal format
+//					  CreateOpenGL - report version created
+//		25.04.24	- Correct GLDXformat for default GL_RGBA
+//		26.04.24	- GLformatName - revise names
+//		06.05.24	- Add more logs for wglDX function failure
+//	Version 2.007.014
+//		26.06.14	- Restore LoadTexturePixels for 20% speed gain
+//
+// ====================================================================================
+//
+//	Copyright (c) 2021-2024, Lynn Jarvis. All rights reserved.
+//
+//	Redistribution and use in source and binary forms, with or without modification, 
+//	are permitted provided that the following conditions are met:
+//
+//		1. Redistributions of source code must retain the above copyright notice, 
+//		   this list of conditions and the following disclaimer.
+//
+//		2. Redistributions in binary form must reproduce the above copyright notice, 
+//		   this list of conditions and the following disclaimer in the documentation 
+//		   and/or other materials provided with the distribution.
+//
+//	THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"	AND ANY 
+//	EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES 
+//	OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE	ARE DISCLAIMED. 
+//	IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
+//	INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, 
+//	PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+//	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+//	LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+//	OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+#include "SpoutGL.h"
+
+// ================================================
+
+
+// Class: spoutGL
+// Base class for OpenGL texture sharing using the NVIDIA GL/DX interop extensions.
+// This class should not be used directly because it is the base for the Spout, SpoutSender and SpoutReceiver classes.
+// Refer to the Spout class for further documentation and details.
+spoutGL::spoutGL()
+{
+	m_SenderName[0] = 0;
+	m_SenderNameSetup[0] = 0;
+	m_Width = 0;
+	m_Height = 0;
+
+	m_bAuto = true;
+	m_bCPU = false;
+	m_bUseGLDX = true;
+	m_bTextureShare = true;
+	m_bCPUshare = false; // Texture share assumed by default
+	m_bSenderCPU = false;
+	m_bSenderGLDX = true;
+	
+	m_bConnected = false;
+	m_bInitialized = false;
+	m_bSpoutPanelOpened = false;
+	m_bSpoutPanelActive = false;
+	m_bUpdated = false;
+	m_bMirror = false;
+	m_bSwapRB = false;
+	m_bGLDXdone = false; // Compatibility test not done yet
+
+	m_glTexture = 0;
+	m_TexID = 0;
+	m_TexWidth = 0;
+	m_TexHeight = 0;
+	m_TexFormat = GL_RGBA;
+	m_fbo = 0;
+
+	m_dxShareHandle = NULL; // Shared texture handle
+	m_pSharedTexture = nullptr; // DX11 shared texture
+	m_DX11format = DXGI_FORMAT_B8G8R8A8_UNORM; // Default compatible with DX9
+	m_dwFormat = m_DX11format;
+	m_pStaging[0] = nullptr; // DX11 staging textures
+	m_pStaging[1] = nullptr;
+	m_Index = 0;
+	m_NextIndex = 0;
+
+	m_hInteropDevice = NULL;
+	m_hInteropObject = NULL;
+	m_hWnd = nullptr;
+
+	// For CreateOpenGL and CloseOpenGL
+	m_hdc = nullptr;
+	m_hwndButton = nullptr;
+	m_hRc = nullptr;
+
+	// OpenGL extensions
+	m_caps = 0; // nothing loaded yet
+	m_bExtensionsLoaded = false;
+	m_bBGRAavailable = false;
+	m_bFBOavailable  = false;
+	m_bBLITavailable = false;
+	m_bSWAPavailable = false;
+	m_bGLDXavailable = false;
+	m_bCOPYavailable = false;
+	m_bPBOavailable = true; // Assume true until tested by LoadGLextensions
+	m_bCONTEXTavailable = false;
+
+	// PBO support
+	PboIndex = 0;
+	NextPboIndex = 0;
+	m_pbo[0] = m_pbo[1] = m_pbo[2] = m_pbo[3] = 0;
+	m_nBuffers = 2; // default number of buffers used
+
+	// Check the user selected Auto share mode
+	DWORD dwValue = 0;
+	if (ReadDwordFromRegistry(HKEY_CURRENT_USER, "Software\\Leading Edge\\Spout", "Auto", &dwValue))
+		m_bAuto = (dwValue == 1);
+
+	// Check for 2.006 registry CPU mode
+	if (ReadDwordFromRegistry(HKEY_CURRENT_USER, "Software\\Leading Edge\\Spout", "CPU", &dwValue))
+		m_bCPU = (dwValue == 1);
+
+	// Check the user selected buffering mode
+	if (ReadDwordFromRegistry(HKEY_CURRENT_USER, "Software\\Leading Edge\\Spout", "Buffering", &dwValue))
+		m_bPBOavailable = (dwValue == 1);
+
+	// Number of PBO buffers user selected
+	m_nBuffers = 2;
+	if(ReadDwordFromRegistry(HKEY_CURRENT_USER, "Software\\Leading Edge\\Spout", "Buffers", &dwValue))
+		m_nBuffers = (int)dwValue;
+
+	// Find version number from the registry
+	// Set by Spout Installer (2005, 2006, etc.) or by SpoutSettings for 2.007 and later
+	if (ReadDwordFromRegistry(HKEY_CURRENT_USER, "Software\\Leading Edge\\Spout", "Version", &dwValue)) {
+		m_SpoutVersion = (int)dwValue;
+	}
+	else {
+		// Get number string e.g. "2.007.009"
+		std::string str = GetSDKversion();
+		// Remove all "." chars
+		str.erase(std::remove(str.begin(), str.end(), '.'), str.end());
+		m_SpoutVersion = std::stoi(str);
+	}
+
+	// 2.006 memoryshare mode
+	// Only set if 2.006 SpoutSettings has been used
+	// Removed by 2.007 SpoutSettings
+	m_bMemoryShare = GetMemoryShareMode();
+
+	// Extensions are loaded in OpenSpout() if a context is not available here
+	LoadGLextensions();
+
+}
+
+//---------------------------------------------------------
+// Function: ~spoutGL()
+// Destructor
+// Note that an OpenGL context is necessary for release of
+// OpenGL objects in CleanupGL and CleanupInterop.
+// Similarly, a DirectX device is necessary in CleanupDX11.
+// If the context or device is lost, release of memory allocated
+// to these objects is handled by the driver.
+//
+spoutGL::~spoutGL()
+{
+	try {
+
+		// Release sender
+		if (m_bInitialized) {
+			sendernames.ReleaseSenderName(m_SenderName);
+			frame.CleanupFrameCount();
+			frame.CloseAccessMutex();
+		}
+
+		// Close 2.006 or buffer shared memory if used
+		memoryshare.Close();
+
+		// Release sync event if used
+		frame.CloseFrameSync();
+
+		// Release interop
+		CleanupInterop();
+
+		// Release OpenGL resources 
+		CleanupGL();
+
+		// Finally release DirectX resources and device
+		CleanupDX11();
+	}
+	catch (...) {
+		MessageBoxA(NULL, "Exception in SpoutGL destructor", NULL, MB_OK);
+	}
+}
+
+//
+// Group: OpenGL shared texture
+//
+
+//---------------------------------------------------------
+// Function: BindSharedTexture
+// Bind OpenGL shared texture.
+bool spoutGL::BindSharedTexture()
+{
+	// Only for GL/DX interop mode
+	if (!m_hInteropDevice || !m_hInteropObject)
+		return false;
+
+	bool bRet = false;
+	// Wait for access to the shared texture
+	if (frame.CheckTextureAccess(m_pSharedTexture)) {
+		// lock dx object
+		if (LockInteropObject(m_hInteropDevice, &m_hInteropObject) == S_OK) {
+			// Bind our shared OpenGL texture
+			glBindTexture(GL_TEXTURE_2D, m_glTexture);
+			// Leave interop and mutex both locked for success
+			bRet = true;
+		}
+		else {
+			// Release interop lock and allow texture access for fail
+			UnlockInteropObject(m_hInteropDevice, &m_hInteropObject);
+			bRet = false;
+		}
+		// Release mutex and allow access to the texture
+		frame.AllowTextureAccess(m_pSharedTexture);
+	}
+
+	return bRet;
+
+} // end BindSharedTexture
+
+//---------------------------------------------------------
+// Function: UnBindSharedTexture
+// Un-bind OpenGL shared texture.
+bool spoutGL::UnBindSharedTexture()
+{
+	// Only for GL/DX interop mode
+	if (!m_hInteropDevice || !m_hInteropObject)
+		return false;
+
+	// Unbind our shared OpenGL texture
+	glBindTexture(GL_TEXTURE_2D, 0);
+	// unlock dx object
+	UnlockInteropObject(m_hInteropDevice, &m_hInteropObject);
+	// Release mutex and allow access to the texture
+	frame.AllowTextureAccess(m_pSharedTexture);
+
+	return true;
+
+} // end UnBindSharedTexture
+
+//---------------------------------------------------------
+// Function: GetSharedTextureID
+// OpenGL shared texture ID.
+GLuint spoutGL::GetSharedTextureID()
+{
+	return m_glTexture;
+}
+
+//
+// Group: Graphics compatibility
+//
+
+//---------------------------------------------------------
+// Function: GetAutoShare
+// Get auto GPU/CPU share depending on compatibility.
+bool spoutGL::GetAutoShare()
+{
+	return m_bAuto;
+}
+
+//---------------------------------------------------------
+// Function: SetAutoShare
+// Set auto GPU/CPU share depending on compatibility.
+void spoutGL::SetAutoShare(bool bAuto)
+{
+	m_bAuto = bAuto;
+}
+
+//---------------------------------------------------------
+// Function: GetCPUShare
+// Get CPU share for the application.
+// This is determined by compatibility or set by the application
+bool spoutGL::GetCPUshare()
+{
+	return m_bCPUshare;
+}
+
+//---------------------------------------------------------
+// Function: SetCPUshare
+// Set CPU share for the application.
+// If set false, GL/DX compatibility is re-tested.
+// CPU share can also be set globally with "SetCPUmode".
+void spoutGL::SetCPUshare(bool bCPU)
+{
+	m_bCPUshare = bCPU;
+
+	if (m_bCPUshare) {
+		m_bTextureShare = false;
+	}
+	else {
+		// Re-test GL/DX compatibility
+		SpoutLogNotice("spoutGL::SetCPUshare(%d) - re-testing GL/DX compatibility", bCPU);
+		OpenSpout(true);
+		if (m_bCPUshare) {
+			SpoutLogWarning("    Cannot disable CPU sharing mode. System is not GL/DX compatible");
+		}
+	}
+
+}
+
+//---------------------------------------------------------
+// Function: IsGLDXready
+// OpenGL texture share compatibility.
+bool spoutGL::IsGLDXready()
+{
+	return m_bUseGLDX;
+}
+
+//
+// Group: For direct access if necessary
+//
+
+//---------------------------------------------------------
+// Function: OpenSpout
+//
+// Initialize OpenGL and DX11.
+//
+//     - Open DirectX and check for availability
+//     - Load extensions and check for availability and function
+//     - Compatibility test for use or GL/DX interop
+//     - Optionally re-test compatibility even if already initialized
+//
+// Failure means that DirectX is not available.
+//
+// OpenGL GPU texture sharing is used only if GL/DX compatible (m_bUseGLDX = true).
+//
+// DirectX CPU backup is used if :
+//
+//     - Graphics is incompatible (m_bUseGLDX = false)
+//
+//   and
+//
+//     - The user has selected "Auto" share in SpoutSettings (m_bAuto = false)
+//
+//   or
+//
+//     - The user has selected CPU mode (2.006 setting or by registry edit of the CPU entry)
+//
+// Class flags :
+//
+//   m_bUseGLDX -       graphics GL/DX compatibility, not the sharing method to be used
+//   m_bTextureShare -  use OpenGL GL/DX methods
+//   m_bCPUshare -      use DirectX CPU methods
+//   Neither method -   do not process at all
+//
+	
+bool spoutGL::OpenSpout(bool bRetest)
+{
+	// Return if already initialized and not re-testing compatibility
+	// Look for DirectX device to prevent repeat
+	// m_hInteropDevice is created in CreateInterop 
+	if (spoutdx.GetDX11Device() != nullptr && !bRetest)
+		return true;
+
+	 // This is the start, so make a new line in the log
+	SpoutLog("");
+#if defined _M_X64
+	SpoutLogNotice("spoutGL::OpenSpout - 64bit 2.007 - this 0x%.7X", PtrToUint(this));
+#elif defined _M_ARM64
+	SpoutLogNotice("spoutGL::OpenSpout - 64bit ARM 2.007 - this 0x%.7X", PtrToUint(this));
+#else
+	SpoutLogNotice("spoutGL::OpenSpout - 32bit 2.007 - this 0x%.7X", PtrToUint(this));
+#endif
+
+	m_bUseGLDX = false;
+	m_bTextureShare = false;
+	m_bCPUshare = false;
+
+	// DirectX capability is the minimum
+	if (!OpenDirectX()) {
+		SpoutLogFatal("spoutGL::OpenSpout - Could not initialize DirectX 11");
+		return false;
+	}
+
+	// Default CPU share until tested
+	m_bCPUshare = true;
+
+	// DirectX is OK
+	// OpenGL device context is needed to go on
+	HDC hdc = wglGetCurrentDC();
+	if (hdc) {
+		// Get a window handle
+		m_hWnd = WindowFromDC(hdc);
+		// Load extensions
+		if (LoadGLextensions()) {
+			// If DirectX and OpenGL are both OK - test GLDX compatibility
+			// For a re-test, create a new interop device in GLDXReady()
+			if (bRetest) {
+				CleanupInterop();
+			}
+			SpoutLogNotice("spoutGL::OpenSpout - GL extensions loaded sucessfully");
+			// Drop through for detail notices
+		}
+		else {
+			SpoutLogFatal("spoutGL::OpenSpout - Could not load GL extensions");
+			return false;
+		}
+	}
+	else {
+		SpoutLogFatal("spoutGL::OpenSpout - Cannot get GL device context");
+		// This is OpenGL, but DirectX shared textures might still work OK (see SpoutDX)
+		return false;
+	}
+	
+	//
+	// OpenGL GPU texture sharing is used if GL/DX compatible (m_bUseGLDX = true)
+	//
+	// DirectX CPU backup is used if :
+	//     Graphics is incompatible (m_bUseGLDX = false)
+	//   and
+	//     The user has selected "Auto" share in SpoutSettings (m_bAuto = false)
+	//   or
+	//     The user has selected CPU mode (2.006 setting or by registry edit of the CPU entry)
+	//
+	//   m_bUseGLDX      - shows graphics GL/DX compatibility, not the sharing method to be used
+	//   m_bTextureShare - use OpenGL GL/DX methods
+	//   m_bCPUshare     - use DirectX CPU methods
+	//   Neither method  - do not process at all
+	//
+
+	if (GLDXready()) {
+		// GL/DX compatible -  m_bUseGLDX is set true
+		SpoutLogNotice("    GL/DX interop compatible");
+	}
+	else {
+		// Not GL/DX compatible -  m_bUseGLDX is set false
+		SpoutLogWarning("spoutGL::OpenSpout - system is not compatible with GL/DX interop");
+	}
+
+	// Work out sharing methods
+	m_bTextureShare = false; // use GL/DX methods
+	m_bCPUshare = false; // Use DirectX CPU methods
+
+	// Texture share requires GL/DX compatibility
+	m_bTextureShare = m_bUseGLDX;
+
+	// If not compatible, Use CPU share only if Auto has been set in SpoutSettings
+	if (!m_bTextureShare && m_bAuto)
+		m_bCPUshare = true;
+
+	// Or CPU share over-ride for 2.006 setting or direct registry edit
+	if (m_bCPU) {
+		m_bTextureShare = false; // Do not use texture share
+		m_bCPUshare = true; // Use CPU share
+	}
+
+	// Show the sharing method to be used
+	if (m_bTextureShare) {
+		SpoutLogNotice("    Using GPU OpenGL GL/DX methods");
+	}
+	else if (m_bCPUshare) {
+		SpoutLogWarning("   Using CPU DirectX methods");
+	}
+	else {
+		SpoutLogWarning("   Cannot share textures");
+	}
+	
+	return true;
+
+}
+
+//---------------------------------------------------------
+// Function: OpenDirectX
+// Initialize DirectX (D3D11 only)
+bool spoutGL::OpenDirectX()
+{
+	SpoutLogNotice("spoutGL::OpenDirectX");
+	return spoutdx.OpenDirectX11();
+}
+
+//---------------------------------------------------------
+// Function: CloseDirectX
+// Close DirectX and free resources
+void spoutGL::CloseDirectX()
+{
+	SpoutLogNotice("spoutGL::CloseDirectX()");
+
+	// Release linked DirectX shared texture
+	if (m_pSharedTexture)
+		spoutdx.ReleaseDX11Texture(GetDX11Device(), m_pSharedTexture);
+	m_pSharedTexture = nullptr;
+	m_dxShareHandle = nullptr;
+
+	// Flush context to avoid deferred release
+	spoutdx.Flush();
+
+	spoutdx.CloseDirectX11();
+
+}
+
+//---------------------------------------------------------
+// Function: GetDX11format
+//   Get sender DX11 shared texture format
+DXGI_FORMAT spoutGL::GetDX11format()
+{
+	return m_DX11format;
+}
+
+//---------------------------------------------------------
+// Function: SetDX11format
+//   Set sender DX11 shared texture format
+//
+//   Texture formats compatible with WGL_NV_DX_interop
+//
+//   https://www.khronos.org/registry/OpenGL/extensions/NV/WGL_NV_DX_interop.txt
+//   https://www.khronos.org/registry/OpenGL/extensions/NV/WGL_NV_DX_interop2.txt
+//
+//   D3DFMT_A8R8G8B8                         = 21
+//
+//   D3DFMT_X8R8G8B8                         = 22
+//
+//   DXGI_FORMAT_R32G32B32A32_FLOAT          = 2
+//
+//   DXGI_FORMAT_R16G16B16A16_FLOAT          = 10
+//
+//   DXGI_FORMAT_R16G16B16A16_UNORM          = 11
+//
+//   DXGI_FORMAT_R16G16B16A16_SNORM          = 13
+//
+//   DXGI_FORMAT_R10G10B10A2_UNORM           = 24
+//
+//   DXGI_FORMAT_R8G8B8A8_UNORM              = 28
+//
+//   DXGI_FORMAT_R8G8B8A8_UNORM_SRGB         = 29
+//
+//   DXGI_FORMAT_R8G8B8A8_SNORM              = 31
+//
+//   DXGI_FORMAT_B8G8R8A8_UNORM              = 87 (default)
+//
+//   DXGI_FORMAT_B8G8R8X8_UNORM              = 88
+//
+void spoutGL::SetDX11format(DXGI_FORMAT textureformat)
+{
+	m_DX11format = textureformat;
+	m_dwFormat = static_cast<DWORD>(m_DX11format); // DWORD used throughout
+}
+
+//---------------------------------------------------------
+// Function: DX11format
+//
+//  OpenGL compatible DX11 format
+//
+//	GL_RGBA, GL_RGBA8        (DXGI_FORMAT_R8G8B8A8_UNORM)
+//	GL_RGB10_A2              (DXGI_FORMAT_R10G10B10A2_UNORM)
+//	GL_RGB16, GL_RGBA16	     (DXGI_FORMAT_R16G16B16A16_UNORM)
+//	GL_RGB16F, GL_RGBA16F    (DXGI_FORMAT_R16G16B16A16_FLOAT)
+//	GL_RGB32F, GL_RGBA32F    (DXGI_FORMAT_R32G32B32A32_FLOAT)
+//  GL_RGB, GL_RGB8, GL_RGBA, GL_BGRA (DXGI_FORMAT_B8G8R8A8_UNORM) // default
+//
+DXGI_FORMAT spoutGL::DX11format(GLint glformat)
+{
+	DXGI_FORMAT d3dformat = DXGI_FORMAT_B8G8R8A8_UNORM;
+	switch (glformat) {
+	case GL_RGBA8: // 0x8058
+		d3dformat = DXGI_FORMAT_R8G8B8A8_UNORM;
+		break;
+	case GL_RGB10_A2: // 0x8059
+		d3dformat = DXGI_FORMAT_R10G10B10A2_UNORM;
+		break;
+	case GL_RGB16:  // 0x8054
+	case GL_RGBA16: // 0x805B
+		d3dformat = DXGI_FORMAT_R16G16B16A16_UNORM;
+		break;
+	case GL_RGB16F:  // 0x881B
+	case GL_RGBA16F: // 0x881A
+		d3dformat = DXGI_FORMAT_R16G16B16A16_FLOAT;
+		break;
+	case GL_RGB32F:  // 0x8815
+	case GL_RGBA32F: // 0x8814
+		d3dformat = DXGI_FORMAT_R32G32B32A32_FLOAT;
+		break;
+	default:
+		// GL_RGB  0x1907
+		// GL_RGB8 0x8051
+		// GL_RGBA 0x1908
+		// GL_BGRA 0x08E1
+		// Use default DXGI_FORMAT_B8G8R8A8_UNORM
+		break;
+	}
+
+	return d3dformat;
+}
+
+//---------------------------------------------------------
+// Function: GLDXformat
+//   Return DX11 compatible OpenGL format
+GLint spoutGL::GLDXformat(DXGI_FORMAT textureformat)
+{
+	DXGI_FORMAT d3dformat = textureformat;
+	if (d3dformat == DXGI_FORMAT_UNKNOWN)
+		d3dformat = m_DX11format;
+
+	GLint glformat = GL_RGBA;
+	switch (d3dformat) {
+		// DirectX 9
+		case D3DFMT_A8R8G8B8:
+		case D3DFMT_X8R8G8B8:
+		// DirectX 11
+		case DXGI_FORMAT_B8G8R8X8_UNORM:
+		case DXGI_FORMAT_B8G8R8A8_UNORM:
+			glformat = GL_RGBA;
+			break;
+		case DXGI_FORMAT_R8G8B8A8_SNORM:
+		case DXGI_FORMAT_R8G8B8A8_UNORM:
+		case DXGI_FORMAT_R8G8B8A8_UNORM_SRGB:
+			glformat = GL_RGBA8;
+			break;
+		case DXGI_FORMAT_R10G10B10A2_UNORM:
+			glformat = GL_RGB10_A2;
+			break;
+		case DXGI_FORMAT_R16G16B16A16_SNORM:
+		case DXGI_FORMAT_R16G16B16A16_UNORM:
+			glformat = GL_RGBA16;
+			break;
+		case DXGI_FORMAT_R16G16B16A16_FLOAT:
+			glformat = GL_RGBA16F;
+			break;
+		case DXGI_FORMAT_R32G32B32_FLOAT:
+		case DXGI_FORMAT_R32G32B32A32_FLOAT:
+			glformat = GL_RGBA32F;
+			break;
+		default:
+			break;
+	}
+	return glformat;
+}
+
+//---------------------------------------------------------
+// Function:GLformat
+//   Return OpenGL texture internal format
+GLint spoutGL::GLformat(GLuint TextureID, GLuint TextureTarget)
+{
+	// https://www.khronos.org/opengl/wiki/Image_Format
+	// https://moderngl.readthedocs.io/en/latest/topics/texture_formats.html
+	GLint glformat = 0;
+	glBindTexture(TextureTarget, TextureID);
+	glGetTexLevelParameteriv(TextureTarget, 0, GL_TEXTURE_INTERNAL_FORMAT, &glformat);
+	glBindTexture(TextureTarget, 0);
+	return glformat;
+}
+
+//---------------------------------------------------------
+// Function:GLformatName
+//   Return OpenGL format description for compatible DX11 formats
+std::string spoutGL::GLformatName(GLint glformat)
+{
+	std::string formatname = "unknown";
+	GLint format = glformat;
+
+	// If not specified, get from the global DX11 format
+	if (format == 0)
+		format = GLDXformat();
+
+	switch (format) {
+		case GL_RGBA16:
+			formatname = "16 bit RGBA";
+			break;
+		case GL_RGBA16F:
+			formatname = "16 bit RGBA float";
+			break;
+		case GL_RGBA32F:
+			formatname = "32 bit RGBA float";
+			break;
+		case GL_RGB10_A2:
+			formatname = "10 bit RGB A2";
+			break;
+		case GL_RGBA8:
+			formatname = "8 bit RGBA";
+			break;
+		case GL_RGBA:
+			formatname = "RGBA";
+			break;
+		case GL_BGRA:
+			formatname = "8 bit BGRA";
+			break;
+		default:
+			break;
+	}
+	return formatname;
+}
+
+//---------------------------------------------------------
+// Function: CreateOpenGL
+//
+// Create an OpenGL window and context for situations where there is none.
+// The version created depends on that supported by the operating system
+// and is reported after creation.
+//
+// Not necessary if an OpenGL context is already available.
+// Always call CloseOpenGL() on application close.
+//
+// OpenGL support is required.
+// Include in your application header file :
+//     #include <gl/GL.h>
+//     #pragma comment (lib, "opengl32.lib")
+//
+bool spoutGL::CreateOpenGL()
+{
+
+	if (!wglGetCurrentContext()) {
+
+		m_hdc = nullptr;
+		m_hwndButton = nullptr;
+		m_hRc = nullptr;
+
+		// We only need an OpenGL context with no render window because we don't draw to it
+		// so create an invisible dummy button window. This is then independent from the host
+		// program window (GetForegroundWindow). If SetPixelFormat has been called on the
+		// host window it cannot be called again. This caused a problem in Mapio.
+		// https://msdn.microsoft.com/en-us/library/windows/desktop/dd369049%28v=vs.85%29.aspx
+		//
+		// CS_OWNDC allocates a unique device context for each window in the class. 
+		//
+		if (!m_hwndButton || !IsWindow(m_hwndButton)) {
+			m_hwndButton = CreateWindowA("BUTTON",
+				"SpoutOpenGL",
+				WS_OVERLAPPEDWINDOW | CS_OWNDC,
+				0, 0, 32, 32,
+				NULL, NULL, NULL, NULL);
+		}
+
+		if (!m_hwndButton) {
+			SpoutLogError("spoutGL::CreateOpenGL - no hwnd");
+			return false;
+		}
+
+		m_hdc = GetDC(m_hwndButton);
+		if (!m_hdc) {
+			SpoutLogError("spoutGL::CreateOpenGL - no hdc");
+			CloseOpenGL();
+			return false;
+		}
+
+		// https://learn.microsoft.com/en-us/windows/win32/api/wingdi/ns-wingdi-pixelformatdescriptor
+		PIXELFORMATDESCRIPTOR pfd;
+		ZeroMemory(&pfd, sizeof(pfd));
+		pfd.nSize = sizeof(pfd);
+		pfd.nVersion = 1;
+		pfd.dwFlags = PFD_DRAW_TO_WINDOW | PFD_SUPPORT_OPENGL | PFD_DOUBLEBUFFER;
+		pfd.iPixelType = PFD_TYPE_RGBA;
+		pfd.cColorBits = 32;
+		pfd.cDepthBits = 16;
+		pfd.iLayerType = PFD_MAIN_PLANE;
+		const int iFormat = ChoosePixelFormat(m_hdc, &pfd);
+		if (!iFormat) {
+			SpoutLogError("spoutGL::CreateOpenGL - pixel format error");
+			CloseOpenGL();
+			return false;
+		}
+
+		if (!SetPixelFormat(m_hdc, iFormat, &pfd)) {
+			const DWORD dwError = GetLastError();
+			// 2000 (0x7D0) The pixel format is invalid.
+			// Caused by repeated call of the SetPixelFormat function
+			char temp[128]={};
+			sprintf_s(temp, "spoutGL::CreateOpenGL - SetPixelFormat Error %lu (0x%4.4lX)", dwError, dwError);
+			SpoutLogError("%s", temp);
+			CloseOpenGL();
+			return false;
+		}
+
+		m_hRc = wglCreateContext(m_hdc);
+		if (!m_hRc) {
+			SpoutLogError("spoutGL::CreateOpenGL - could not create OpenGL context");
+			CloseOpenGL();
+			return false;
+		}
+
+		wglMakeCurrent(m_hdc, m_hRc);
+		if (!wglGetCurrentContext()) {
+			SpoutLogError("spoutGL::CreateOpenGL - no OpenGL context");
+			CloseOpenGL();
+			return false;
+		}
+		SpoutLogNotice("    OpenGL window created OK");
+	}
+	else {
+		SpoutLogNotice("    OpenGL context exists");
+	}
+
+	// Load the extensions (returns true if already loaded)
+	if (!LoadGLextensions()) {
+		SpoutLogWarning("OpenGL extensions failed to load");
+		return false;
+	}
+
+	int glVersion[2] = { 0, 0 };
+	glGetIntegerv(GL_MAJOR_VERSION, &glVersion[0]);
+	glGetIntegerv(GL_MINOR_VERSION, &glVersion[1]);
+	SpoutLogNotice("CreateOpenGL - Version %d.%d", glVersion[0], glVersion[1]);
+
+	return true;
+
+}
+
+//---------------------------------------------------------
+// Function: CloseOpenGL
+// Close OpenGL window and release resources
+bool spoutGL::CloseOpenGL()
+{
+
+	SpoutLogNotice("spoutGL::CloseOpenGL() - m_hRc = 0x%.7X : m_hdc = 0x%.7X", PtrToUint(m_hRc), PtrToUint(m_hdc) );
+
+	// Properly kill the OpenGL window
+	if (m_hRc) {
+		if (!wglMakeCurrent(NULL, NULL)) { // Are We Able To Release The DC And RC Contexts?
+			SpoutLogError("spoutGL::CloseOpenGL - release of DC and RC failed");
+			return false;
+		}
+		if (!wglDeleteContext(m_hRc)) { // Are We Able To Delete The RC?
+			SpoutLogError("spoutGL::CloseOpenGL - release rendering context failed");
+			return false;
+		}
+		m_hRc = NULL;
+	}
+
+	if (m_hdc && !ReleaseDC(m_hwndButton, m_hdc)) { // Are We Able To Release The DC
+		SpoutLogError("spoutGL::CloseOpenGL - release device context Failed");
+		m_hdc = NULL;
+		return false;
+	}
+
+	if (m_hwndButton && !DestroyWindow(m_hwndButton)) { // Are We Able To Destroy The Window?
+		SpoutLogError("spoutGL::CloseOpenGL - could not release hWnd");
+		m_hwndButton = NULL;
+		return false;
+	}
+
+	SpoutLogNotice("    Closed OpenGL window OK");
+
+	return true;
+}
+
+//---------------------------------------------------------
+// Class initialization status
+bool spoutGL::IsSpoutInitialized()
+{
+	return m_bInitialized;
+}
+
+//
+// GLDXready
+//
+// Hardware compatibility test
+//
+//  o Check that extensions for GL/DX interop are available
+//
+//  o GLDXready
+//      Checks operation of GL/DX interop functions
+//		and creates an interop device for success
+//
+//	o m_bUseGLDX - true for GL/DX interop availability
+//
+bool spoutGL::GLDXready()
+{
+	// === Simulate failure for debugging ===
+	// SpoutLogNotice("spoutGL::GLDXready - simulated compatibility failure");
+	// m_bUseGLDX = false;
+	// m_bTextureShare = false;
+	// m_bCPUshare = true;
+	// return false;
+
+	// === Simulate success to skip test for debugging ===
+	// SpoutLogNotice("spoutGL::GLDXready - simulated compatibility success");
+	// m_bUseGLDX = true;
+	// m_bTextureShare = true;
+	// m_bCPUshare = false;
+	// return true;
+	
+	// Return if the test has already been done
+	if (m_bGLDXdone) {
+		SpoutLogNotice("spoutGL::GLDXready - test previously completed");
+		return m_bUseGLDX;
+	}
+
+	//
+	// Test whether the NVIDIA OpenGL/DirectX interop extensions function correctly.
+	//
+	// Create dummy textures and use the interop functions.
+	// Must be called after OpenDirectX.
+	// Success means the GLDX interop functions can be used.
+	// Other errors should not happen if OpenDirectX succeeded
+	//
+	ID3D11Texture2D* pTexture = nullptr; // the DX11 texture for the test link
+	HANDLE dxShareHandle = nullptr; // Shared texture handle
+	// HANDLE hInteropObject = nullptr; // handle to the DX/GL interop object
+	GLuint glTexture = 0; // the OpenGL texture linked to the shared DX texture
+
+	SpoutLogNotice("spoutGL::GLDXready - testing for GL/DX interop compatibility");
+
+	// Assume not GLDX interop compatible until all tests pass
+	m_bUseGLDX = false;
+
+	if (!spoutdx.GetDX11Device()) {
+		SpoutLogError("spoutGL::GLDXready - No D3D11 device");
+		return false;
+	}
+
+	// DirectX is OK but check for availabilty of the GL/DX extensions.
+	if (!m_bGLDXavailable) {
+		// The extensions required for texture access are not available.
+		SpoutLogError("spoutGL::GLDXready - GL/DX interop extensions not available");
+		return false;
+	}
+
+	SpoutLogNotice("    GL/DX interop extensions available");
+
+	// Create an opengl texture for the test
+	glGenTextures(1, &glTexture);
+	if (glTexture == 0) {
+		SpoutLogError("spoutGL::GLDXready - glGenTextures failed");
+		return false;
+	}
+
+	// Create a shared texture for the link test
+	if (!spoutdx.CreateSharedDX11Texture(spoutdx.GetDX11Device(),
+		256, 256, DXGI_FORMAT_B8G8R8A8_UNORM, // default
+		&pTexture, dxShareHandle)) {
+		glDeleteTextures(1, &glTexture);
+		SpoutLogError("spoutGL::GLDXready - CreateSharedDX11Texture failed");
+		return false;
+	}
+
+	SpoutLogNotice("    Linking test - OpenGL texture (0x%.7X) DX11 texture (0x%.7X)", glTexture, PtrToUint(pTexture));
+
+	// Link the DirectX texture to the OpenGL texture
+	// Use the global m_hInteropObject so that CleanupInterop works
+	m_hInteropObject = LinkGLDXtextures(spoutdx.GetDX11Device(), pTexture, glTexture);
+	if (!m_hInteropObject) {
+		spoutdx.ReleaseDX11Texture(spoutdx.GetDX11Device(), pTexture);
+		glDeleteTextures(1, &glTexture);
+		glTexture = 0;
+		pTexture = nullptr;
+		dxShareHandle = nullptr;
+		// It is possible that extensions for the GL/DX interop load OK
+		// but that the GL/DX interop functions fail.
+		// This has been noted on dual graphics machines with the NVIDIA Optimus driver.
+		SpoutLogWarning("spoutGL::GLDXready - GL/DX interop functions failed");
+	}
+	else {
+
+		// Release the interop objects created for the test
+		// They are re-created in CreateInterop
+		if (!wglDXUnregisterObjectNV(m_hInteropDevice, m_hInteropObject))
+			SpoutLogWarning("spoutGL::GLDXready - wglDXUnregisterObjectNV failed");
+		if(!wglDXCloseDeviceNV(m_hInteropDevice))
+			SpoutLogWarning("spoutGL::GLDXready - wglDXCloseDeviceNV failed");
+		m_hInteropObject = nullptr;
+		m_hInteropDevice = nullptr;
+
+		// Release the test textures after the interop objects have been released
+		spoutdx.ReleaseDX11Texture(spoutdx.GetDX11Device(), pTexture);
+		glDeleteTextures(1, &glTexture);
+		glTexture = 0;
+		pTexture = nullptr;
+		dxShareHandle = nullptr;
+
+		// Flush context to avoid deferred release
+		spoutdx.Flush();
+
+		// Set compatibility flag
+		m_bUseGLDX = true;
+
+		SpoutLogNotice("    Test OpenGL and DX11 textures created and linked OK");
+
+	}
+
+	// Now GLDXready() has set m_bUseGLDX is set to use the GL/DX interop or not.
+	
+	// Use of texture sharing or CPU backup is assessed from
+	// user settings (retrieved with GetAutoShare)
+	// and actual GL/DX compatibility (retrieved with GetGLDXready)
+	//
+	// The result is tested in OpenSpout
+	//
+	// Texture sharing is used if GL/DX compatible (m_bUseGLDX = true)
+	//
+	// CPU backup is used if :
+	//     Graphics is incompatible (m_bUseGLDX = false)
+	//   and
+	//     The user has selected "Auto" share in SpoutSettings (m_bAuto = false)
+	//   or
+	//     The user has forced CPU mode by registry edit of the CPU entry 	
+	//
+	// Otherwise no sharing is performed.
+
+	// If not GLDX compatible, LinkGLDXtexture will not be called (see CreateDX11interop)
+	// ReadDX11Texture and WriteDX11Texture will be used instead via CPU staging textures 
+
+	// Set a class flag so the test is not repeated
+	m_bGLDXdone = true;
+
+	return m_bUseGLDX;
+
+}
+
+
+//---------------------------------------------------------
+bool spoutGL::SetHostPath(const char *sendername)
+{
+	SharedTextureInfo info;
+	if (!sendernames.getSharedInfo(sendername, &info)) {
+		SpoutLogWarning("spoutGL::SetHostPath(%s) - could not get sender info", sendername);
+		return false;
+	}
+	char exepath[256]={};
+	GetModuleFileNameA(NULL, exepath, sizeof(exepath));
+	// Description is defined as wide chars, but the path is stored as byte chars
+	strcpy_s((char*)info.description, 256, exepath);
+	if (!sendernames.setSharedInfo(sendername, &info)) {
+		SpoutLogWarning("spoutGL::SetHostPath(%s) - could not set sender info", sendername);
+	}
+	return true;
+
+}
+
+
+//----------------------------------------------------------
+// SetSenderID - set top two bits of 32 bit partner ID field
+//
+//   bCPU  - means "using CPU sharing methods"
+//     1000 0000 0000 0000 0000 0000 0000 0000 = 0x80000000
+//   bGLDX - means "hardware is compatible with OpenGL/DirectX interop"
+//     0100 0000 0000 0000 0000 0000 0000 0000 = 0x40000000
+//   Both set - means "hardware is GL/DX compatible but using CPU sharing methods"
+//     1100 0000 0000 0000 0000 0000 0000 0000 = 0xC0000000
+// 
+// 2.006 senders may or may not have these bits set, but will rarely have the exact values.
+//
+bool spoutGL::SetSenderID(const char *sendername, bool bCPU, bool bGLDX)
+{
+	// Texture share and hardware compatibility assumed by default
+	m_bSenderCPU = false;
+	m_bSenderGLDX = true;
+
+	// Set the requested flags to the PartnerID field of sender shared memory.
+	// If the method succeeds, set class flags.
+	if (sendernames.SetSenderID(sendername, bCPU, bGLDX)) {
+			m_bSenderCPU  = bCPU;
+			m_bSenderGLDX = bGLDX;
+			return true;
+	}
+	return false;
+}
+
+//
+// Protected functions
+//
+
+
+//
+// Create shared DirectX texture and OpenGL texture and link with GL/DX interop
+//
+// https://registry.khronos.org/OpenGL/extensions/NV/WGL_NV_DX_interop.txt
+// https://registry.khronos.org/OpenGL/extensions/NV/WGL_NV_DX_interop2.txt
+//
+bool spoutGL::CreateInterop(unsigned int width, unsigned int height, DWORD dwFormat, bool bReceive)
+{
+
+	// Avoid repeats if interop failure flag is set
+	// Cleared by CleaunpInterop
+	if (m_bInteropFailed)
+		return false;
+
+	// Check for dimensions out of bounds
+	// D3D11_REQ_TEXTURE2D_U_OR_V_DIMENSION (16384)
+	if (width > 16384 || height > 16384)
+		return false;
+
+
+	SpoutLogNotice("spoutGL::CreateInterop");
+
+	// The texture to link with OpenGL
+	ID3D11Texture2D* pLinkedTexture = nullptr;
+
+	// Compatible formats - see SetDX11format
+	// A directX 11 receiver accepts DX9 formats
+	// Default DXGI_FORMAT_B8G8R8A8_UNORM
+	// unless set otherwise by SetDX11format(DXGI_FORMAT textureformat)
+	DWORD format = m_DX11format;
+	if (dwFormat > 0 && dwFormat != format) {
+		format = dwFormat; // Use the passed texture format
+		SetDX11format((DXGI_FORMAT)format); // Set the global texture format
+	}
+
+	if (bReceive) {
+		// The receiver must have retrieved a handle from the sender
+		// A DirectX texture is opened from the sender share handle.
+		if (!m_dxShareHandle || !m_pSharedTexture) {
+			SpoutLogError("spoutGL::CreateInterop - no receiver texture handle");
+			// Write diagnostics to a log file
+			DoDiagnostics("spoutGL::CreateInterop - no receiver texture handle");
+			// Set interop failure flag to avoid repeats (cleared in CleaunpInterop)
+			m_bInteropFailed = true;
+			return false;
+		}
+
+		// Use the texture already created from the sender share handle for linking to OpenGL.
+		pLinkedTexture = m_pSharedTexture;
+	}
+	else {
+		// A sender creates or re-creates the linked DX11 texture
+		// and a new share handle that receivers can use.
+		m_dxShareHandle = nullptr;
+		if (!spoutdx.CreateSharedDX11Texture(spoutdx.GetDX11Device(),
+			width, height,
+			(DXGI_FORMAT)format, // Default DXGI_FORMAT_B8G8R8A8_UNORM
+			&m_pSharedTexture,
+			m_dxShareHandle, // Handle for receivers
+			false, false)) { // Keyed shared texture, NT handle - defaults false
+				if (m_pSharedTexture) m_pSharedTexture->Release();
+				m_pSharedTexture = nullptr;
+				m_dxShareHandle = nullptr;
+				char tmp[256]{};
+				sprintf_s(tmp, 256, "spoutGL::CreateInterop - sender CreateSharedDX11Texture failed (%ux%u format 0x%X)",
+					width, height, format);
+				SpoutLogFatal(tmp);
+				DoDiagnostics(tmp);
+				// Set interop failure flag to avoid repeats (cleared in CleaunpInterop)
+				m_bInteropFailed = true;
+				return false;
+		}
+		pLinkedTexture = m_pSharedTexture;
+	}
+
+	// Create or re-create the class OpenGL texture.
+	// The texture has body after it is linked to the shared DirectX texture.
+	if (m_glTexture) glDeleteTextures(1, &m_glTexture);
+	glGenTextures(1, &m_glTexture);
+
+	// The interop may already be released but check
+	// here so the function can be used independently.
+	if (m_hInteropDevice && m_hInteropObject) {
+		SpoutLogNotice("    Re-registering interop");
+		if(!wglDXUnregisterObjectNV(m_hInteropDevice, m_hInteropObject))
+			SpoutLogNotice("spoutGL::CreateInterop - wglDXUnregisterObjectNV failed");
+		m_hInteropObject = nullptr;
+	}
+
+	// Link the shared DirectX texture to the OpenGL texture
+	// This registers for interop and associates the opengl texture with the dx texture
+	// by calling wglDXRegisterObjectNV which returns a handle to the interop object
+	// to manage access to the textures. An interop device is created if it does not exist yet.
+	m_hInteropObject = LinkGLDXtextures((void*)spoutdx.GetDX11Device(), pLinkedTexture, m_glTexture);
+	if (!m_hInteropObject) {
+		SpoutLogFatal("spoutGL::CreateInterop - LinkGLDXtextures failed");
+		// Write diagnostics to a log file
+		DoDiagnostics("spoutGL::CreateInterop - LinkGLDXtextures failed");
+		// Set interop failure flag to avoid repeats (cleared in CleaunpInterop)
+		m_bInteropFailed = true;
+		return false;
+	}
+
+	SpoutLogNotice("    m_pSharedTexture [0x%.7X] m_dxShareHandle [0x%.7X] m_DX11format [0x%X] (%d)", 
+		PtrToUint(pLinkedTexture), LOWORD(m_dxShareHandle), m_DX11format, m_DX11format);
+	SpoutLogNotice("    m_hInteropObject = 0x%.7X", LOWORD(m_hInteropObject));
+
+	// Update class dimensions
+	m_Width  = width;
+	m_Height = height;
+
+	// Create an fbo if not already
+	// A utility texture (m_TexID) will be created later if needed for texture invert
+	if (m_fbo == 0)	glGenFramebuffersEXT(1, &m_fbo);
+
+	// Important to reset PBO index
+	// Pbos are created or re-created in UnloadTexturePixels
+	PboIndex = 0;
+	NextPboIndex = 0;
+
+	// Also reset staging texture index
+	m_Index = 0;
+	m_NextIndex = 0;
+
+	// Clear interop failed flag
+	m_bInteropFailed = false;
+
+	return true;
+
+}
+
+//
+//	Link a shared DirectX texture to an OpenGL texture
+//	and create a GLDX interop object handle
+//
+//	IN	pSharedTexture  Pointer to shared the DirectX texture
+//	IN	dxShareHandle   Handle of the DirectX texture to be shared
+//	IN	glTextureID     ID of the OpenGL texture that is to be linked to the shared DirectX texture
+//	Returns             Handle to the GL/DirectX interop object (the shared texture)
+//
+HANDLE spoutGL::LinkGLDXtextures(void* pDXdevice, void* pSharedTexture,  GLuint glTexture)
+{
+	HANDLE hInteropObject = nullptr;
+	DWORD dwError = 0;
+	char tmp[128]={};
+
+	SpoutLogNotice("spoutGL::LinkGLDXtextures - device 0x%X, texture 0x%X, GL texture ID %d",
+		PtrToUint(pDXdevice), PtrToUint(pSharedTexture), glTexture);
+
+	// Are the GL/DX interop extensions loaded ?
+	if (!wglDXOpenDeviceNV
+		|| !wglDXSetResourceShareHandleNV
+		|| !wglDXRegisterObjectNV
+		|| !wglDXCloseDeviceNV) {
+		SpoutLogError("spoutGL::LinkGLDXtextures - no GL/DX extensions");
+		return nullptr;
+	}
+
+	// Prepare the DirectX device for interoperability with OpenGL
+	// The return value is a handle to a GL/DirectX interop device.
+	if (!m_hInteropDevice) {
+		try {
+			m_hInteropDevice = wglDXOpenDeviceNV(pDXdevice);
+		}
+		catch (...) {
+			SpoutLogError("spoutGL::LinkGLDXtextures - wglDXOpenDeviceNV exception");
+			return NULL;
+		}
+	}
+	// SpoutLogNotice("    wglDXOpenDeviceNV 0x%7.7X", PtrToUint(m_hInteropDevice));
+
+	// Report the error if wglDXOpenDeviceNV failed
+	if (!m_hInteropDevice) {
+		dwError = GetLastError();
+		sprintf_s(tmp, 128, "spoutGL::LinkGLDXtextures : wglDXOpenDeviceNV(0x%.7X) no Interop device - error %lu (0x%.X)\n",
+			LOWORD(pDXdevice), dwError, LOWORD(dwError));
+		// Other errors reported
+		// 1008, 0x3F0 - ERROR_NO_TOKEN
+		switch (LOWORD(dwError)) {
+		case 0:
+			strcat_s(tmp, 128, "    No error");
+			break;
+		case ERROR_OPEN_FAILED:
+			strcat_s(tmp, 128, "    Could not open the Direct3D device.");
+			break;
+		case ERROR_NOT_SUPPORTED:
+			// This can be caused either by passing in a device from an unsupported DirectX
+			// version, or by passing in a device referencing a display adapter that is
+			// not accessible to the GL.
+			strcat_s(tmp, 128, "    The dxDevice is not supported.");
+			break;
+		default:
+			strcat_s(tmp, 128, "    Unknown error.");
+			break;
+		}
+		SpoutLogError("%s", tmp);
+
+		return NULL;
+	}
+
+	// wglDXSetResourceShareHandle does not need to be called for DirectX
+	// version 10 and 11 resources. Calling this function for DirectX 10
+	// and 11 resources is not an error but has no effect.
+	
+	// Prepare the DirectX texture for use by OpenGL
+	// register for interop and associate the opengl texture with the dx texture
+	// Returns a handle that can be used for sharing functions
+	try {
+		hInteropObject = wglDXRegisterObjectNV(m_hInteropDevice,
+			pSharedTexture,	// DX texture
+			glTexture,		// OpenGL texture
+			GL_TEXTURE_2D,	// Must be TEXTURE_2D - multisampling not supported
+			WGL_ACCESS_READ_WRITE_NV); // A sender will write and a receiver will read
+	}
+	catch (...) {
+		SpoutLogError("spoutGL::LinkGLDXtextures - wglDXRegisterObjectNV exception");
+		return NULL;
+	}
+	// SpoutLogNotice("    wglDXRegisterObjectNV 0x%7.7X", LOWORD(hInteropObject));
+
+	if (!hInteropObject) {
+		// Noted C007006E returned on failure.
+		// Error codes are 32-bit values, but expected results are in the low word.
+		// 006E is ERROR_OPEN_FAILED (110L)
+		dwError = GetLastError();
+		sprintf_s(tmp, 128, "spoutGL::LinkGLDXtextures - wglDXRegisterObjectNV :error %u, (0x%.X)\n",
+			LOWORD(dwError), LOWORD(dwError));
+		switch (LOWORD(dwError)) {
+		case 0:
+			strcat_s(tmp, 128, "    No error");
+		break;
+		case ERROR_INVALID_HANDLE:
+			strcat_s(tmp, 128, "    No GL context is current.");
+			break;
+		case ERROR_INVALID_DATA:
+			strcat_s(tmp, 128, "    Incorrect GL name, type or access parameters.");
+			break;
+		case ERROR_OPEN_FAILED:
+			strcat_s(tmp, 128, "    Failed to open the Direct3D resource.");
+			break;
+		default:
+			strcat_s(tmp, 128, "    Unknown error.");
+			break;
+		}
+		SpoutLogError("%s", tmp);
+
+		// Error so close interop device
+		if (m_hInteropDevice) {
+			if (!wglDXCloseDeviceNV(m_hInteropDevice)) {
+				SpoutLogError("spoutGL::LinkGLDXtextures - wglDXCloseDeviceNV failed");
+				return nullptr;
+			}
+			m_hInteropDevice = nullptr;
+		}
+
+	}
+
+	return hInteropObject;
+
+}
+
+HANDLE spoutGL::GetInteropDevice()
+{
+	return m_hInteropDevice; // Handle to the GL/DX interop device
+}
+
+HANDLE spoutGL::GetInteropObject()
+{
+	return m_hInteropObject; // Handle to the GL/DX interop object
+}
+
+ID3D11Texture2D* spoutGL::GetDXsharedTexture()
+{
+	return m_pSharedTexture; // Shared texture
+}
+
+//
+//	GL/DX Interop lock
+//
+//	A return value of S_OK indicates that all objects were
+//    successfully locked.  Other return values indicate an
+//    error. If the function returns false, none of the objects will be locked.
+//
+//	Attempting to access an interop object via GL when the object is
+//    not locked, or attempting to access the DirectX resource through
+//    the DirectX API when it is locked by GL, will result in undefined
+//    behavior and may result in data corruption or program
+//    termination. Likewise, passing invalid interop device or object
+//    handles to this function has undefined results, including program
+//    termination.
+//
+//	Note that only one GL context may hold the lock on the
+//    resource at any given time --- concurrent access from multiple GL
+//    contexts is not currently supported.
+//
+//	DISCUSSION: The Lock/Unlock calls serve as synchronization points
+//    between OpenGL and DirectX. They ensure that any rendering
+//    operations that affect the resource on one driver are complete
+//    before the other driver takes ownership of it.
+//
+//	This function assumes only one object
+//
+//	Must return S_OK (0) - otherwise the error can be checked.
+//
+HRESULT spoutGL::LockInteropObject(HANDLE hDevice, HANDLE *hObject)
+{
+	DWORD dwError = 0;
+	HRESULT hr = 0;
+
+	if (!hDevice || !hObject || !*hObject) {
+		return E_HANDLE;
+	}
+
+	// lock dx object
+	if (wglDXLockObjectsNV(hDevice, 1, hObject)) {
+		return S_OK;
+	}
+	else {
+		dwError = GetLastError();
+		switch (LOWORD(dwError)) {
+		case ERROR_BUSY:			// One or more of the objects in <hObjects> was already locked.
+			hr = E_ACCESSDENIED;	// General access denied error
+			SpoutLogError("spoutGL::LockInteropObject - ERROR_BUSY");
+			break;
+		case ERROR_INVALID_DATA:	// One or more of the objects in <hObjects>
+									// does not belong to the interop device
+									// specified by <hDevice>.
+			hr = E_ABORT;			// Operation aborted
+			SpoutLogError("spoutGL::LockInteropObject - ERROR_INVALID_DATA");
+			break;
+		case ERROR_LOCK_FAILED:	// One or more of the objects in <hObjects> failed to 
+			hr = E_ABORT;			// Operation aborted
+			SpoutLogError("spoutGL::LockInteropObject - ERROR_LOCK_FAILED");
+			break;
+		default:
+			hr = E_FAIL;			// unspecified error
+			SpoutLogError("spoutGL::LockInteropObject - UNKNOWN_ERROR");
+			break;
+		} // end switch
+	} // end false
+
+	return hr;
+
+} // LockInteropObject
+
+
+//
+// Must return S_OK (0) - otherwise the error can be checked.
+//
+HRESULT spoutGL::UnlockInteropObject(HANDLE hDevice, HANDLE *hObject)
+{
+	DWORD dwError = 0;
+	HRESULT hr = 0;
+
+	if (!hDevice || !hObject || !*hObject) {
+		return E_HANDLE;
+	}
+
+	if (wglDXUnlockObjectsNV(hDevice, 1, hObject)) {
+		return S_OK;
+	}
+	else {
+		dwError = GetLastError();
+		switch (LOWORD(dwError)) {
+		case ERROR_NOT_LOCKED:
+			hr = E_ACCESSDENIED;
+			SpoutLogError("spoutGL::UnLockInteropObject - ERROR_NOT_LOCKED");
+			break;
+		case ERROR_INVALID_DATA:
+			SpoutLogError("spoutGL::UnLockInteropObject - ERROR_INVALID_DATA");
+			hr = E_ABORT;
+			break;
+		case ERROR_LOCK_FAILED:
+			hr = E_ABORT;
+			SpoutLogError("spoutGL::UnLockInteropObject - ERROR_LOCK_FAILED");
+			break;
+		default:
+			hr = E_FAIL;
+			SpoutLogError("spoutGL::UnLockInteropObject - UNKNOWN_ERROR");
+			break;
+		} // end switch
+	} // end fail
+
+	return hr;
+
+} // end UnlockInteropObject
+
+
+// Clean up the gldx interop
+bool spoutGL::CleanupInterop()
+{
+	// Clear interop failure flag
+	m_bInteropFailed = false;
+
+	// Already released ?
+	if (m_hInteropDevice || m_hInteropObject) {
+		// These things need an opengl context so check
+		if (wglGetCurrentContext()) {
+			SpoutLogNotice("spoutGL::CleanupInterop - interop device = 0x%7.7X, interop object = 0x%7.7X", PtrToUint(m_hInteropDevice), PtrToUint(m_hInteropObject));
+			if (m_hInteropDevice && m_hInteropObject) {
+				SpoutLogNotice("    wglDXUnregisterObjectNV");
+				if (!wglDXUnregisterObjectNV(m_hInteropDevice, m_hInteropObject)) {
+					SpoutLogNotice("spoutGL::CleanupInterop - wglDXUnregisterObjectNV failed : could not un-register interop");
+				}
+				m_hInteropObject = nullptr;
+			}
+			else {
+				if (!m_hInteropDevice)
+					SpoutLogWarning("spoutGL::CleanupInterop - null interop device");
+				if (!m_hInteropObject)
+					SpoutLogWarning("spoutGL::CleanupInterop - null interop object");
+			}
+			if (m_hInteropDevice) {
+				SpoutLogNotice("    wglDXCloseDeviceNV");
+				if (!wglDXCloseDeviceNV(m_hInteropDevice)) {
+					SpoutLogNotice("spoutGL::CleanupInterop - wglDXCloseDeviceNV failed : could not close interop");
+				}
+				m_hInteropDevice = nullptr;
+			}
+		}
+		else {
+			SpoutLogWarning("spoutGL::CleanupInterop() - no GL context");
+		}
+	}
+
+	m_hInteropObject = nullptr;
+	m_hInteropDevice = nullptr;
+
+	return true;
+
+}
+
+//---------------------------------------------------------
+void spoutGL::CleanupGL()
+{
+	SpoutLogNotice("spoutGL::CleanupGL");
+
+	// Release OpenGL resources if there is a context
+	if (wglGetCurrentContext()) {
+
+		// Make sure no texture is bound
+		glBindTexture(GL_TEXTURE_2D, 0);
+
+		// Delete the fbo before the texture
+		if (m_fbo > 0) glDeleteFramebuffersEXT(1, &m_fbo);
+		m_fbo = 0;
+
+		// Delete the linked OpenGL texture
+		if (m_glTexture > 0) glDeleteTextures(1, &m_glTexture);
+		m_glTexture = 0;
+
+		if (m_TexID > 0)
+			glDeleteTextures(1, &m_TexID);
+
+		if (m_pbo[0] > 0)
+			glDeleteBuffers(m_nBuffers, m_pbo);
+
+		m_TexID = 0;
+		m_pbo[0] = m_pbo[1] = m_pbo[2] = m_pbo[3] = 0;
+	}
+	else {
+		SpoutLogWarning("spoutGL::CleanupGL() - no GL context");
+	}
+
+	// Release the received D3D11 shared texture
+	if (m_pSharedTexture) {
+		spoutdx.ReleaseDX11Texture(GetDX11Device(), m_pSharedTexture);
+		m_pSharedTexture = nullptr;
+	}
+
+	// The share handle is created again for a sender
+	// and retrieved from the sender for a receiver
+	m_dxShareHandle = nullptr;
+
+	// Staging textures for CPU share are also released in CleanupDX11
+	// But release them here to allow for situations where DirectX is not released
+	if (m_pStaging[0]) spoutdx.ReleaseDX11Texture(spoutdx.GetDX11Device(), m_pStaging[0]);
+	if (m_pStaging[1]) spoutdx.ReleaseDX11Texture(spoutdx.GetDX11Device(), m_pStaging[1]);
+	m_pStaging[0] = nullptr;
+	m_pStaging[1] = nullptr;
+	m_Index = 0;
+	m_NextIndex = 0;
+
+	m_Width = 0;
+	m_Height = 0;
+
+	// ReleaseReceiver calls CleanupGL before restoring m_SenderName
+	// ReleaseSender clears the name
+
+	// Flush D3D11 context to avoid deferred release
+	spoutdx.Flush();
+
+	// Do not close DirectX device
+
+}
+
+// If a class OpenGL texture has not been created or it is a different size, create a new one
+// Typically used for texture copy and invert
+void spoutGL::CheckOpenGLTexture(GLuint &texID, GLenum GLformat, unsigned int width,  unsigned int height)
+{
+	if (texID == 0 || texID != m_TexID 
+			|| GLformat != m_TexFormat 
+			|| width    != m_TexWidth 
+			|| height   != m_TexHeight) {
+		InitTexture(texID, GLformat, width, height);
+		m_TexID = texID;
+		m_TexWidth  = width;
+		m_TexHeight = height;
+		m_TexFormat = (DWORD)GLformat;
+
+	}
+}
+
+// Initialize OpenGL texture
+void spoutGL::InitTexture(GLuint &texID, GLenum GLformat, unsigned int width, unsigned int height)
+{
+	if (texID != 0) glDeleteTextures(1, &texID);
+	glGenTextures(1, &texID);
+
+	// Get current texture binding
+	GLint texturebinding;
+	glGetIntegerv(GL_TEXTURE_BINDING_2D, &texturebinding);
+
+	// Pixel type
+	GLenum type = GL_UNSIGNED_BYTE; // 8 bit RGBA
+	if (GLformat == GL_RGBA16) // Bit depth 16 bits
+		type = GL_UNSIGNED_SHORT;
+	else if (GLformat == GL_RGBA16F || GLformat == GL_RGBA32F) // float
+		type = GL_FLOAT;
+
+	glBindTexture(GL_TEXTURE_2D, texID);
+	glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, GLformat, type, NULL);
+	glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+	glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+	glBindTexture(GL_TEXTURE_2D, texturebinding);
+
+}
+
+
+//
+// COPY AN OPENGL TEXTURE TO THE SHARED OPENGL TEXTURE
+//
+// Allows for a texture attached to the fbo
+// where the input texture can be larger than the shared texture
+// and Width and height are the used portion. Only the used part is copied.
+//
+bool spoutGL::WriteGLDXtexture(GLuint TextureID, GLuint TextureTarget,
+	unsigned int width, unsigned int height, bool bInvert, GLuint HostFBO)
+{
+	// Only for GL/DX interop mode
+	if (!m_hInteropDevice || !m_hInteropObject)
+		return false;
+
+	// Specify greater here because the width/height passed can be smaller
+	if (width > m_Width || height > m_Height)
+		return false;
+
+	// Create an fbo if not already
+	if (m_fbo == 0)
+		glGenFramebuffersEXT(1, &m_fbo);
+
+	// Wait for access to the shared texture
+	if (frame.CheckTextureAccess(m_pSharedTexture)) {
+		// lock dx interop object
+		if (LockInteropObject(m_hInteropDevice, &m_hInteropObject) == S_OK) {
+			// Write to the shared texture
+			if (SetSharedTextureData(TextureID, TextureTarget, width, height, bInvert, HostFBO)) {
+				// Increment the sender frame counter for successful write
+				frame.SetNewFrame();
+			}
+			// unlock dx object
+			UnlockInteropObject(m_hInteropDevice, &m_hInteropObject);
+		}
+		// Release mutex and allow access to the texture
+		frame.AllowTextureAccess(m_pSharedTexture);
+	}
+
+	return true;
+
+} // end WriteGLDXTexture
+
+
+//
+// COPY THE SHARED OPENGL TEXTURE TO AN OPENGL TEXTURE
+//
+bool spoutGL::ReadGLDXtexture(GLuint TextureID, GLuint TextureTarget, unsigned int width, unsigned int height, bool bInvert, GLuint HostFBO)
+{
+	// No interop, no copy
+	if (!m_hInteropDevice || !m_hInteropObject) {
+		return false;
+	}
+
+	// No shared DX11 texture, no copy
+	if (!m_pSharedTexture)
+		return false;
+
+	// No texture read or zero OpenGL texture (allowed for by ReceiveTexture)
+	// the shared texture can be accessed directly
+	if (TextureID == 0) {
+		return true;
+	}
+
+	// width and height must be the same as the shared texture
+	if (width != m_Width || height != m_Height) {
+		return false;
+	}
+
+	// No new frame, do not block
+	// GetNewFrame updates sender frame count and fps
+	if (!frame.GetNewFrame()) {
+		return true;
+	}
+
+	// Read the shared texture if the sender has produced a new frame
+	bool bRet = true; // Error only if texture read fails
+
+	// Wait for access to the shared texture
+	if (frame.CheckTextureAccess(m_pSharedTexture)) {
+		if (LockInteropObject(m_hInteropDevice, &m_hInteropObject) == S_OK) {
+			// Copy the linked OpenGL texture (m_glTexture) to the user OpenGL texture
+			bRet = CopyTexture(m_glTexture, GL_TEXTURE_2D, TextureID, TextureTarget, width, height, bInvert, HostFBO);
+			UnlockInteropObject(m_hInteropDevice, &m_hInteropObject);
+		}
+		// Release mutex and allow access to the texture
+		frame.AllowTextureAccess(m_pSharedTexture);
+	}
+
+	return bRet;
+
+} // end ReadGLDXTexture
+
+
+// Interop must be locked for this function to access the shared texture
+bool spoutGL::SetSharedTextureData(GLuint TextureID, GLuint TextureTarget, unsigned int width, unsigned int height, bool bInvert, GLuint HostFBO)
+{
+	GLenum status = 0;
+	bool bRet = false;
+
+	// "TextureID" can be zero if it is attached to the fbo
+	// m_fbo is a local FBO, "m_glTexture" is destination texture,
+	// width/height are the dimensions of the destination texture.
+	// Because two fbos are used, the input texture can be larger than the shared texture
+	// Width and height are the used portion and only the used part is copied
+	if (TextureID == 0 && HostFBO >= 0) {
+		if (glCheckFramebufferStatusEXT(GL_FRAMEBUFFER_EXT) == GL_FRAMEBUFFER_COMPLETE_EXT) {
+			// The input texture is attached to attachment point 0 of the fbo passed in (HostFBO)
+			// Bind our local fbo for draw
+			glBindFramebufferEXT(GL_DRAW_FRAMEBUFFER_EXT, m_fbo);
+			// Draw to the first attachment point
+			glDrawBuffer(GL_COLOR_ATTACHMENT0_EXT);
+			// Attach the texture we write into (the shared texture)
+			glFramebufferTexture2DEXT(GL_DRAW_FRAMEBUFFER_EXT, GL_COLOR_ATTACHMENT0_EXT, GL_TEXTURE_2D, m_glTexture, 0);
+			// Check draw fbo for completeness
+			status = glCheckFramebufferStatusEXT(GL_FRAMEBUFFER_EXT);
+			if (status == GL_FRAMEBUFFER_COMPLETE_EXT) {
+				if (m_bBLITavailable) {
+					if (bInvert)
+						// Copy from one framebuffer to the other while flipping upside down 
+						glBlitFramebufferEXT(0, 0, width, height, 0, height, width, 0, GL_COLOR_BUFFER_BIT, GL_NEAREST);
+					else
+						// Do not flip during blit
+						glBlitFramebufferEXT(0, 0, width, height, 0, 0, width, height, GL_COLOR_BUFFER_BIT, GL_NEAREST);
+				}
+				else {
+					// No fbo blit extension
+					// Copy from the host fbo (input texture attached) to the shared texture
+					glBindTexture(GL_TEXTURE_2D, m_glTexture);
+					glCopyTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, 0, 0, width, height);
+					glBindTexture(GL_TEXTURE_2D, 0);
+				}
+				bRet = true;
+			}
+			else {
+				PrintFBOstatus(status);
+				bRet = false;
+			}
+		}
+		else {
+			PrintFBOstatus(status);
+			bRet = false;
+		}
+		// restore host fbo
+		glBindFramebufferEXT(GL_FRAMEBUFFER_EXT, HostFBO);
+	}
+	else if (TextureID > 0) {
+		// There is a valid texture passed in, copy the input texture to the
+		// destination shared texture (m_glTexture), inverting as necessary.
+		// Both textures must be the same size.
+		bRet = CopyTexture(TextureID, TextureTarget, m_glTexture, GL_TEXTURE_2D, width, height, bInvert, HostFBO);
+	}
+
+	return bRet;
+
+}
+
+//
+// COPY IMAGE PIXELS TO THE OPENGL SHARED TEXTURE
+//
+bool spoutGL::WriteGLDXpixels(const unsigned char* pixels,
+	unsigned int width, unsigned int height,
+	GLenum glFormat, bool bInvert, GLuint HostFBO)
+{
+	if (width != m_Width || height != m_Height || !pixels)
+		return false;
+
+	// Use a GL texture so that WriteTexture can be used
+	// Create or resize a local OpenGL texture
+	CheckOpenGLTexture(m_TexID, glFormat, width, height);
+
+	// Transfer the pixels to the local texture
+	glPixelStorei(GL_UNPACK_ALIGNMENT, 1); // In case of RGB pixel data
+
+	if (m_bPBOavailable) {
+		// 17-30 msec 3840x2160
+		LoadTexturePixels(m_TexID, GL_TEXTURE_2D, width, height, pixels, glFormat);
+	}
+	else {
+		// 25-45 msec 3840x2160
+		glBindTexture(GL_TEXTURE_2D, m_TexID);
+		glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, width, height, glFormat, GL_UNSIGNED_BYTE, (GLvoid *)pixels);
+		glBindTexture(GL_TEXTURE_2D, 0);
+	}
+
+	glPixelStorei(GL_UNPACK_ALIGNMENT, 4);
+
+	// Write the local texture to the shared texture and invert if necessary
+	return WriteGLDXtexture(m_TexID, GL_TEXTURE_2D, width, height, bInvert, HostFBO);
+
+} // end WriteGLDXpixels
+
+
+//
+// COPY OPENGL SHARED TEXTURE TO IMAGE PIXELS
+//
+bool spoutGL::ReadGLDXpixels(unsigned char* pixels,
+	unsigned int width, unsigned int height,
+	GLenum glFormat, bool bInvert, GLuint HostFBO)
+{
+	if (!m_hInteropDevice || !m_hInteropObject) {
+		return false;
+	}
+
+	if (width != m_Width || height != m_Height) {
+		return false;
+	}
+
+	// No new frame, do not block
+	if (!frame.GetNewFrame())
+		return true;
+
+	// Read texture pixels for a new frame
+	bool bRet = true; // Error only if pixel read fails
+
+	// retrieve opengl texture data directly to image pixels
+
+	// Wait for access to the shared texture
+	if (frame.CheckTextureAccess(m_pSharedTexture)) {
+
+		// lock gl/dx interop object for access by OpenGL
+		if (LockInteropObject(m_hInteropDevice, &m_hInteropObject) == S_OK) {
+
+			// Set single pixel alignment in case of rgb source
+			if (glFormat == GL_RGB || glFormat == GL_BGR_EXT)
+				glPixelStorei(GL_PACK_ALIGNMENT, 1);
+
+			if (bInvert) {
+				// Create or resize a local OpenGL texture
+				CheckOpenGLTexture(m_TexID, glFormat, width, height);
+				// Copy the shared texture to the local texture, inverting if necessary
+				CopyTexture(m_glTexture, GL_TEXTURE_2D, m_TexID, GL_TEXTURE_2D, width, height, bInvert, HostFBO);
+				// Extract the pixels from the local texture - changing to the user passed format
+				// Use PBO method for maximum speed. ReadTextureData using glReadPixels is half the
+				// speed of using DX11 texture directly (ReadDX11pixels). Note that ReadDX11pixels
+				// has texture access and new frame checks and cannot be used if those checks
+				// have already been made.
+				if (m_bPBOavailable) {
+					bRet = UnloadTexturePixels(m_TexID, GL_TEXTURE_2D, width, height, 0, pixels, glFormat, false, HostFBO);
+				}
+				else {
+					bRet = ReadTextureData(m_TexID, GL_TEXTURE_2D, width, height, 0, pixels, glFormat, false, HostFBO);
+				}
+			}
+			else {
+				// Extract the pixels directly from the shared texture 
+				// dest must be RGBA or RGB width x height
+				if (m_bPBOavailable) {
+					bRet = UnloadTexturePixels(m_glTexture, GL_TEXTURE_2D, width, height, 0, pixels, glFormat, false, HostFBO);
+				}
+				else {
+					bRet = ReadTextureData(m_glTexture, GL_TEXTURE_2D, width, height, 0, pixels, glFormat, false, HostFBO);
+				}
+			}
+
+			// default alignment
+			glPixelStorei(GL_PACK_ALIGNMENT, 4);
+
+		} // interop lock failed
+
+		// Ensure interop object is unlocked
+		UnlockInteropObject(m_hInteropDevice, &m_hInteropObject);
+
+		// Release mutex and allow access to the texture
+		frame.AllowTextureAccess(m_pSharedTexture);
+
+	} // mutex access failed
+
+	return bRet;
+
+} // end ReadGLDXpixels 
+
+
+//
+// Asynchronous Read-back from an OpenGL texture
+//
+// Used by a receiver to read pixels from a shared texture (ReceiveImage)
+//
+// Adapted from : http://www.songho.ca/opengl/gl_pbo.html
+// Also see : https://www.seas.upenn.edu/~pcozzi/OpenGLInsights/OpenGLInsights-AsynchronousBufferTransfers.pdf
+//
+bool spoutGL::UnloadTexturePixels(GLuint TextureID, GLuint TextureTarget,
+	unsigned int width, unsigned int height, unsigned int rowpitch,
+	unsigned char* data, GLenum glFormat,
+	bool bInvert, GLuint HostFBO)
+{
+	void *pboMemory = nullptr;
+	int channels = 4; // RGBA or RGB
+
+	if (!data) {
+		return false;
+	}
+
+	if (glFormat == GL_RGB || glFormat == GL_BGR_EXT) {
+		channels = 3;
+	}
+
+	// Casting first avoids warning C26451: Arithmetic overflow - with VS2022 code review
+	// https://docs.microsoft.com/en-us/visualstudio/code-quality/c26451
+	uint64_t pitch = rowpitch; // row pitch passed in
+	const uint64_t uw = static_cast<uint64_t>(width);
+	if (rowpitch == 0)
+		pitch = uw * channels; // RGB or RGBA
+
+	// Create class fbo if not already
+	if (m_fbo == 0) {
+		SpoutLogNotice("spoutGL::UnloadTexturePixels - creating FBO");
+		glGenFramebuffersEXT(1, &m_fbo);
+	}
+
+	// Create pbos if not already
+	if (m_pbo[0] == 0) {
+		SpoutLogNotice("spoutGL::UnloadTexturePixels - creating %d PBOs", m_nBuffers);
+		glGenBuffers(m_nBuffers, m_pbo);
+		PboIndex = 0;
+		NextPboIndex = 0;
+	}
+
+	PboIndex = (PboIndex + 1) % m_nBuffers;
+	NextPboIndex = (PboIndex + 1) % m_nBuffers;
+
+	// If Texture ID is zero, the texture is already attached to the Host Fbo and we do nothing.
+	// If not, we need to attach the user texture to the class fbo we created.
+	if (TextureID > 0) {
+		// Attach the texture to point 0
+		glBindFramebufferEXT(GL_FRAMEBUFFER_EXT, m_fbo);
+		glFramebufferTexture2DEXT(GL_FRAMEBUFFER_EXT, GL_COLOR_ATTACHMENT0_EXT, TextureTarget, TextureID, 0);
+		// Set the target framebuffer to read
+		glReadBuffer(GL_COLOR_ATTACHMENT0_EXT);
+	}
+	else if (HostFBO == 0) {
+		// If no texture ID, a Host FBO must be provided
+		// testing only - error log will repeat
+		return false;
+	}
+
+	// Bind the PBO
+	glBindBuffer(GL_PIXEL_PACK_BUFFER, m_pbo[PboIndex]);
+
+	// Check it's size
+	GLint size = 0;
+	glGetBufferParameteriv(GL_PIXEL_PACK_BUFFER, GL_BUFFER_SIZE, &size);
+	if (size > 0 && size != (int)(pitch * height)) {
+		// All PBOs must be re-created
+		glBindBuffer(GL_PIXEL_PACK_BUFFER, 0);
+		glBindFramebufferEXT(GL_FRAMEBUFFER_EXT, HostFBO);
+		glDeleteBuffers(m_nBuffers, m_pbo);
+		m_pbo[0] = m_pbo[1] = m_pbo[2] = m_pbo[3] = 0;
+		return false;
+	}
+
+	// Null existing PBO data to avoid a stall
+	// This allocates memory for the PBO pitch*height wide
+	const GLsizeiptr buffersize = (GLsizeiptr)(pitch * height);
+	glBufferData(GL_PIXEL_PACK_BUFFER, buffersize, 0, GL_STREAM_READ);
+
+	// Read pixels from framebuffer to PBO - glReadPixels() should return immediately.
+	const GLint rowbytes = (int)pitch / channels; // row length in pixels
+	glPixelStorei(GL_PACK_ROW_LENGTH, rowbytes); // row length in pixels
+	glReadPixels(0, 0, width, height, glFormat, GL_UNSIGNED_BYTE, (GLvoid *)0);
+	glPixelStorei(GL_PACK_ROW_LENGTH, 0);
+
+	// If there is data in the next pbo from the previous call, read it back
+	glBindBuffer(GL_PIXEL_PACK_BUFFER, m_pbo[NextPboIndex]);
+
+	// Map the PBO to process its data by CPU
+	pboMemory = glMapBuffer(GL_PIXEL_PACK_BUFFER, GL_READ_ONLY);
+
+	// glMapBuffer can return NULL when called the first time
+	// when the next pbo has not been filled with data yet
+	glGetError(); // remove the last error
+
+	if (pboMemory && data) {
+		// Update data directly from the mapped buffer.
+		spoutcopy.CopyPixels((const unsigned char*)pboMemory, (unsigned char*)data, rowbytes, height, glFormat, bInvert);
+		glUnmapBuffer(GL_PIXEL_PACK_BUFFER);
+	}
+	// skip the copy rather than return false.
+
+	// Back to conventional pixel operation
+	glBindBuffer(GL_PIXEL_PACK_BUFFER, 0);
+
+	// Restore the previous fbo binding
+	glBindFramebufferEXT(GL_FRAMEBUFFER_EXT, HostFBO);
+
+	return true;
+
+}
+
+// Streaming texture pixel load
+// From : http://www.songho.ca/opengl/gl_pbo.html
+// Approximately 20% faster than using glTexSubImage2D alone
+// GLformat can be default GL_BGRA or GL_RGBA
+bool spoutGL::LoadTexturePixels(GLuint TextureID, GLuint TextureTarget,
+	unsigned int width, unsigned int height, 
+	const unsigned char* data, int GLformat, bool bInvert)
+{
+	void* pboMemory = NULL;
+
+	// Create pbos if not already
+	if (m_pbo[0] == 0) {
+		SpoutLogNotice("spoutGL::LoadTexturePixels - creating %d PBOs", m_nBuffers);
+		glGenBuffers(m_nBuffers, m_pbo);
+		PboIndex = 0;
+		NextPboIndex = 0;
+	}
+
+	PboIndex = (PboIndex + 1) % m_nBuffers;
+	NextPboIndex = (PboIndex + 1) % m_nBuffers;
+
+	// Bind the texture and PBO
+	glBindTexture(TextureTarget, TextureID);
+	glBindBuffer(GL_PIXEL_UNPACK_BUFFER, m_pbo[PboIndex]);
+
+	// Copy pixels from PBO to the texture - use offset instead of pointer.
+	// glTexSubImage2D redefines a contiguous subregion of an existing
+	// two-dimensional texture image. NULL data pointer reserves space.
+	glTexSubImage2D(TextureTarget, 0, 0, 0, width, height, GLformat, GL_UNSIGNED_BYTE, 0);
+
+	// Bind PBO to update the texture
+	glBindBuffer(GL_PIXEL_UNPACK_BUFFER, m_pbo[NextPboIndex]);
+
+	// Check it's size
+	GLint size = 0;
+	glGetBufferParameteriv(GL_PIXEL_PACK_BUFFER, GL_BUFFER_SIZE, &size);
+	if (size > 0 && size != (int)(width*height*4)) {
+		// All PBOs must be re-created
+		glBindBuffer(GL_PIXEL_UNPACK_BUFFER, 0);
+		glDeleteBuffers(m_nBuffers, m_pbo);
+		m_pbo[0] = m_pbo[1] = m_pbo[2] = m_pbo[3] = 0;
+		return false;
+	}
+
+	// Call glBufferData() with a NULL pointer to clear the PBO data and avoid a stall.
+	glBufferData(GL_PIXEL_UNPACK_BUFFER, width*height*4, 0, GL_STREAM_DRAW);
+
+	// Map the buffer object into client's memory
+	pboMemory = (void*)glMapBuffer(GL_PIXEL_UNPACK_BUFFER, GL_WRITE_ONLY);
+	// Update the mapped buffer directly
+	if (pboMemory) {
+		// Copy pixel data
+		// Use sse2 if the width is divisible by 16
+		spoutcopy.CopyPixels(data, (unsigned char*)pboMemory, 
+			width, height, GLformat, bInvert);
+		glUnmapBuffer(GL_PIXEL_UNPACK_BUFFER); // release the mapped buffer
+	}
+	else {
+		glBindBuffer(GL_PIXEL_UNPACK_BUFFER, 0);
+		return false;
+	}
+
+	// Release PBOs
+	glBindBuffer(GL_PIXEL_UNPACK_BUFFER, 0);
+
+	return true;
+
+}
+
+
+//
+// Read RGB or RGBA pixels from an OpenGL texture
+//
+// nChannels can be 3 (RGB) or 4 (RGBA)
+// Format can be 8 bit or floating point 16 or 32 bit
+// Dest array must match the format :
+// 8 bit unsigned byte, 16 bit unsigned short, or float
+//
+bool spoutGL::ReadTexturePixels(GLuint TextureID, GLuint TextureTarget,
+	unsigned int width, unsigned int height, void* dest,
+	GLenum glFormat, int nChannels)
+{
+	if (!dest)
+		return false;
+
+	// Check OpenGL texture size and return if different
+	int w = 0;
+	int h = 0;
+	glBindTexture(TextureTarget, TextureID);
+	glGetTexLevelParameteriv(GL_TEXTURE_2D, 0, GL_TEXTURE_WIDTH, &w);
+	glGetTexLevelParameteriv(GL_TEXTURE_2D, 0, GL_TEXTURE_HEIGHT, &h);
+	glBindTexture(TextureTarget, 0);
+	if (w != (int)width || h != (int)height) {
+		SpoutLogError("spoutGL::ReadTexturePixels - texure simensions do not match");
+		return false;
+	}
+
+	if (glFormat == GL_RGBA16F || glFormat == GL_RGBA32F) {
+		glBindTexture(TextureTarget, TextureID);
+		// RGB data for float hdr images
+		if (nChannels == 3)
+			glGetTexImage(TextureTarget, 0, GL_RGB, GL_FLOAT, dest);
+		else
+			glGetTexImage(TextureTarget, 0, GL_RGBA, GL_FLOAT, dest);
+		glBindTexture(TextureTarget, 0);
+	}
+	else if (glFormat == GL_RGBA16) { // Bit depth 16 bits
+		glBindTexture(TextureTarget, TextureID);
+		glGetTexImage(TextureTarget, 0, GL_RGBA, GL_UNSIGNED_SHORT, dest);
+		glBindTexture(TextureTarget, 0);
+	}
+	else {
+		// Dest must be RGBA or BGRA width x height
+		glBindTexture(TextureTarget, TextureID);
+		glGetTexImage(TextureTarget, 0, glFormat, GL_UNSIGNED_BYTE, dest);
+		glBindTexture(TextureTarget, 0);
+	}
+
+	return true;
+}
+
+
+
+//
+// Copy OpenGL to DirectX 11 texture via CPU if the GL/DX interop is not available
+//
+// GPU read is from OpenGL.
+// Use multiple PBOs instead of glReadPixels for best speed.
+//
+bool spoutGL::WriteDX11texture(GLuint TextureID, GLuint TextureTarget,
+	unsigned int width, unsigned int height, bool bInvert, GLuint HostFBO)
+{
+	D3D11_MAPPED_SUBRESOURCE mappedSubResource={};
+
+	// Only for DX11 mode
+	if (!spoutdx.GetDX11Context()) {
+		return false;
+	}
+
+	// If a staging texture has not been created or a different size create a new one
+	// Only one staging texture is required. Buffering read from GPU is done by OpenGL PBO.
+	if (!CheckStagingTextures(width, height, 1))
+		return false;
+
+	// Map the DX11 staging texture and write the sender OpenGL texture pixels to it
+	if (SUCCEEDED(spoutdx.GetDX11Context()->Map(m_pStaging[0], 0, D3D11_MAP_WRITE, 0, &mappedSubResource))) {
+
+		// Staging texture width is multiples of 16 and pitch can be greater that width*4
+		// Copy OpenGL texture pixels to the staging texture taking account of the 
+		// destination staging texture row pitch.
+		if (m_bPBOavailable) {
+			if (!UnloadTexturePixels(TextureID, TextureTarget, width, height,
+				mappedSubResource.RowPitch, (unsigned char *)mappedSubResource.pData,
+				GL_BGRA_EXT, bInvert, HostFBO)) {
+					// OpenGL pixel unload failed, Unmap the DirectX texture and return.
+					spoutdx.GetDX11Context()->Unmap(m_pStaging[0], 0);
+					return false;
+			}
+		}
+		else {
+			if (!ReadTextureData(TextureID, TextureTarget, // OpenGL source texture
+				width, height, // width and height of OpenGL texture
+				mappedSubResource.RowPitch, // bytes per line of staging texture
+				(unsigned char *)mappedSubResource.pData, // staging texture pixels
+				GL_BGRA_EXT, bInvert, HostFBO)) {
+					spoutdx.GetDX11Context()->Unmap(m_pStaging[0], 0);
+					return false;
+			}
+		}
+		spoutdx.GetDX11Context()->Unmap(m_pStaging[0], 0);
+
+		// The staging texture is updated with the OpenGL texture data
+		// Write it to the sender's shared texture
+		return WriteTexture(&m_pStaging[0]);
+
+	}
+
+	return false;
+
+} // end WriteDX11texture
+
+//
+// Copy from the shared DX11 texture to an OpenGL texture via CPU staging texture
+// GPU write is to OpenGL
+//
+bool spoutGL::ReadDX11texture(GLuint TextureID, GLuint TextureTarget,
+	unsigned int width, unsigned int height, bool bInvert, GLuint HostFBO)
+{
+	D3D11_MAPPED_SUBRESOURCE mappedSubResource={};
+
+	// Quit for zero texture
+	if (TextureID == 0 || TextureTarget == 0) {
+		return false;
+	}
+
+	// Only for DX11 mode
+	if (!spoutdx.GetDX11Context())
+		return false;
+
+	// Only one staging texture is required because GPU write is to OpenGL
+	if (!CheckStagingTextures(width, height, 1)) {
+		return false;
+	}
+
+	// Read from from the sender shared texture to a staging texture
+	if (!ReadTexture(&m_pStaging[0])) {
+		return false;
+	}
+
+	// Update the application receiving OpenGL texture from the DX11 staging texture
+	// Default format is BGRA. Change if the sender is RGBA.
+	GLenum glFormat = GL_BGRA_EXT;
+	if (m_dwFormat == 28) glFormat = GL_RGBA;
+
+	// Make sure the GPU is ready to access the staging texture 
+	spoutdx.GetDX11Context()->Flush();
+
+	// Map the staging texture to access the sender pixels
+	if (SUCCEEDED(spoutdx.GetDX11Context()->Map(m_pStaging[0], 0, D3D11_MAP_READ, 0, &mappedSubResource))) {
+
+		if (bInvert) {
+			// Create or resize a local OpenGL texture
+			CheckOpenGLTexture(m_TexID, glFormat, width, height);
+			// Copy the DX11 pixels to it
+			glBindTexture(GL_TEXTURE_2D, m_TexID);
+		}
+		else {
+			// Copy the DX11 pixels to the user texture
+			glBindTexture(TextureTarget, TextureID);
+		}
+
+		// Allow for the staging texture for row pitch
+		glPixelStorei(GL_UNPACK_ROW_LENGTH, mappedSubResource.RowPitch / 4); // row length in pixels
+
+		// Get the pixels from the staging texture
+		glTexSubImage2D(TextureTarget, 0, 0, 0, width, height,
+			glFormat, GL_UNSIGNED_BYTE, (const GLvoid *)mappedSubResource.pData);
+
+		glPixelStorei(GL_UNPACK_ROW_LENGTH, 0);
+
+		glBindTexture(GL_TEXTURE_2D, 0);
+		
+		// Copy the local texture to the user texture and invert as necessary
+		if(bInvert)	
+			CopyTexture(m_TexID, GL_TEXTURE_2D, TextureID, TextureTarget, width, height, bInvert, HostFBO);
+
+		spoutdx.GetDX11Context()->Unmap(m_pStaging[0], 0);
+
+		return true;
+	}
+
+	return false;
+
+} // end ReadDX11texture
+
+
+//
+// Group: Data sharing
+//
+//   General purpose data exchange functions using shared memory.
+//   These functions can be used in addition to texture sharing.
+//   Typical uses will be for data attached to the video frame,
+//   commonly referred to as "per frame Metadata".
+//
+//   If strict synchronization is required, the data sharing functions
+//   should be used in combination with event signal functions.
+//
+//      - void SetFrameSync(const char* SenderName);
+//      - bool WaitFrameSync(const char *SenderName, DWORD dwTimeout = 0);
+//
+
+//---------------------------------------------------------
+// Function: WriteMemoryBuffer
+// Write buffer to shared memory.
+//
+//    If shared memory has not been created in advance, it will be
+//    created on the first call to this function at the length specified.
+//
+//    This is acceptable if the data to send is fixed in length.
+//    Otherwise the shared memory should be created in advance of sufficient
+//    size to contain the maximum length expected (see CreateMemoryBuffer).
+//
+//    The map is closed when the sender is released.
+//
+bool spoutGL::WriteMemoryBuffer(const char *name, const char* data, int length)
+{
+	// Quit if 2.006 memoryshare mode
+	if (m_bMemoryShare)
+		return false;
+
+	if (!name || !*name) {
+		SpoutLogError("spoutGL::WriteMemoryBuffer - no name");
+		return false;
+	}
+
+	if (!data) {
+		SpoutLogError("spoutGL::WriteMemoryBuffer - no data");
+		return false;
+	}
+
+	// Create a shared memory map if it does not exist.
+	if (memoryshare.Size() == 0) {
+		// Create a name for the map
+		std::string namestring = name;
+		namestring += "_map";
+		// Create a shared memory map
+		if (!CreateMemoryBuffer(namestring.c_str(), length))
+			return false;
+	}
+
+	char* pBuffer = memoryshare.Lock();
+	if (!pBuffer) {
+		SpoutLogError("spoutGL::WriteMemoryBuffer - no buffer lock");
+		return false;
+	}
+
+	// Write user data to shared memory (skip the first 16 bytes containing the map size)
+	memcpy((pBuffer + 16), data, length);
+
+	// Terminate the shared memory data with a null.
+	// The map is created larger in advance to allow for it.
+	if (memoryshare.Size() > (16 + length))
+		*(pBuffer + 16 + length) = 0;
+
+	memoryshare.Unlock();
+
+	return true;
+
+}
+
+//---------------------------------------------------------
+// Function: ReadMemoryBuffer
+// Read shared memory to a buffer.
+//
+//    Open a memory map and retain the handle.
+//    The map is closed when the receiver is released.
+int spoutGL::ReadMemoryBuffer(const char* name, char* data, int maxlength)
+{
+	// Quit if 2.006 memoryshare mode
+	if (m_bMemoryShare)
+		return 0;
+
+	if (!name || !*name) {
+		SpoutLogError("spoutGL::ReadMemoryBuffer - no name");
+		return 0;
+	}
+
+	if (!data) {
+		SpoutLogError("spoutGL::ReadMemoryBuffer - no data");
+		return 0;
+	}
+
+	// Create a name for the map
+	std::string namestring = name;
+	namestring += "_map";
+
+	// Create a shared memory map for read if not done already
+	if (!memoryshare.Name()) {
+		// Create or open the shared memory. This also creates a mutex
+		// for the reader to lock and unlock the map for reads.
+		if (!memoryshare.Create(namestring.c_str(), maxlength)) {
+			SpoutLogWarning("spoutGL::ReadMemoryBuffer - could not create memory map [%s]", namestring.c_str());
+			return 0;
+		}
+	}
+
+	char* pBuffer = memoryshare.Lock();
+	if (!pBuffer) {
+		SpoutLogError("spoutGL::ReadMemoryBuffer - no buffer lock");
+		return 0;
+	}
+
+	// The memory map includes it's size, saved as the first 16 bytes
+	*(pBuffer + 15) = 0; // End for atoi
+
+	// Number of bytes available for data transfer
+	int nbytes = atoi(pBuffer);
+
+	// Reduce if the user buffer max length is less
+	if (maxlength < nbytes)
+		nbytes = maxlength;
+
+	// Copy bytes from shared memory to the user buffer
+	if (nbytes > 0)
+		memcpy(data, (pBuffer + 16), nbytes);
+
+	// Done with the shared memory pointer
+	memoryshare.Unlock();
+
+	return nbytes;
+}
+
+//---------------------------------------------------------
+// Function: CreateMemoryBuffer
+// Create a shared memory buffer.
+//
+//    Create a memory map and retain the handle.
+//    This function should be called before any buffer write
+//    if the length of the data to send will vary.
+//    The map is closed when the sender is released (see Spout.cpp ReleaseReceiver).
+bool spoutGL::CreateMemoryBuffer(const char *name, int length)
+{
+	// Quit if 2.006 memoryshare mode
+	if (m_bMemoryShare)
+		return false;
+
+	if (!name || !*name) {
+		SpoutLogError("spoutGL::CreateMemoryBuffer - no name");
+		return false;
+	}
+
+	if (memoryshare.Size() > 0) {
+		SpoutLogError("spoutGL::CreateMemoryBuffer - shared memory already exists");
+		return false;
+	}
+
+	// Create a name for the map from the sender name
+	std::string namestring = name;
+	namestring += "_map";
+
+	// The first 16 bytes are reserved to record the number of bytes available
+	// for data transfer. Make the map 16 bytes larger to compensate. 
+	// Add another 16 bytes to allow for a null terminator.
+	// (Use multiples of 16 for alignment to allow for SSE copy : TODO).
+	if (memoryshare.Create(namestring.c_str(), length + 32) == SPOUT_CREATE_FAILED) {
+		SpoutLogError("spoutGL::CreateMemoryBuffer - could not create shared memory");
+		return false;
+	}
+
+	// The length requested is the number of bytes to be
+	// available for data transfer (map data size).
+	char* pBuffer = memoryshare.Lock();
+	if (!pBuffer) {
+		SpoutLogError("spoutGL::CreateMemoryBuffer - no buffer lock");
+		return false;
+	}
+
+	// Convert the map data size to decimal digit chars
+	// directly to the first 16 bytes of the shared memory.
+	_itoa_s(length, pBuffer, 16, 10);
+
+	memoryshare.Unlock();
+	SpoutLogNotice("spoutGL::CreateMemoryBuffer - created shared memory buffer %d bytes", length);
+
+	return true;
+}
+
+
+//---------------------------------------------------------
+// Function: DeleteMemoryBuffer
+// Delete a sender shared memory buffer.
+//
+bool spoutGL::DeleteMemoryBuffer()
+{
+	// Quit if 2.006 memoryshare mode
+	if (m_bMemoryShare)
+		return false;
+
+	// Only the application that creates a map can close it.
+	// The writer creates the map and records the size (memoryshare.Size()).
+	// A reader must open a map to find the size and does not record it.
+	if (memoryshare.Size() == 0) {
+		SpoutLogError("spoutGL::DeleteMemoryBuffer - no shared memory size");
+		return false;
+	}
+
+	memoryshare.Close();
+
+	return true;
+
+}
+
+
+//---------------------------------------------------------
+// Function: GetMemoryBufferSize
+// Get the number of bytes available for data transfer.
+//
+int spoutGL::GetMemoryBufferSize(const char *name)
+{
+	// A writer has created the map (Create) and set the map size.
+	// The data length is recorded in the first 16 bytes.
+	// Another 16 bytes is added to allow for a terminating NULL. (See CreateMemoryBuffer)
+	// The remaining length is the number of bytes available for data transfer.
+	if (memoryshare.Size() > 32) {
+		return memoryshare.Size()-32;
+	}
+
+	// A reader must read the map to get the size.
+	// The size is not set in the SpoutSharedMemory class.
+	// Open a shared memory map for the buffer if it not already.
+	// (after a map is opened, the name is saved in the SpoutSharedMemory class).
+	if (!memoryshare.Name()) {
+		// Create a name for the map
+		std::string namestring = name;
+		namestring += "_map";
+		// Open the shared memory map.
+		// This also creates a mutex for the receiver to lock and unlock the map for reads.
+		if (!memoryshare.Open(namestring.c_str())) {
+			return 0;
+		}
+		SpoutLogNotice("spoutGL::GetMemoryBufferSize - opened sender memory map [%s]", memoryshare.Name());
+	}
+
+	// The map is open and a name for it has been recorded
+	char* pBuffer = memoryshare.Lock();
+	if (!pBuffer) {
+		SpoutLogError("spoutGL::GetMemoryBufferSize - no buffer lock");
+		return 0;
+	}
+
+	// The number of bytes of the memory map available for data transfer
+	// is saved in the first 16 bytes.
+	*(pBuffer + 15) = 0; // End for atoi
+	const int nbytes = atoi(pBuffer);
+
+	memoryshare.Unlock();
+
+	return nbytes;
+
+}
+
+
+// Copy OpenGL texture data to a pixel buffer via fbo
+bool spoutGL::ReadTextureData(GLuint SourceID, GLuint SourceTarget,
+	unsigned int width, unsigned int height, unsigned int pitch,
+	unsigned char* dest, GLenum GLformat, bool bInvert, GLuint HostFBO)
+{
+	if (!m_bFBOavailable || GLformat == GL_RGB || GLformat == GL_BGR_EXT) {
+
+		if (bInvert) {
+
+			// For copy to intermediate invert buffer
+			const unsigned char* src = nullptr;
+
+			// ReadTextureData - create unsigned long variables for temp src char array
+			const unsigned long WxHx3 = static_cast<unsigned long>(width*height*3);
+			const unsigned long WxHx4 = static_cast<unsigned long>(width*height*4);
+
+			if (GLformat == GL_RGB || GLformat == GL_BGR_EXT)
+				src = new unsigned char[WxHx3];
+			else
+				src = new unsigned char[WxHx4];
+
+			glBindTexture(SourceTarget, SourceID);
+			glGetTexImage(SourceTarget, 0, GLformat, GL_UNSIGNED_BYTE, (void*)src);
+			glBindTexture(SourceTarget, 0);
+
+			// Flip the pixel buffer
+			spoutcopy.FlipBuffer(src, dest, width, height, GLformat);
+
+			delete[] src;
+		}
+		else {
+			// dest must be RGBA or RGB width x height
+			glBindTexture(SourceTarget, SourceID);
+			glGetTexImage(SourceTarget, 0, GLformat, GL_UNSIGNED_BYTE, (void*)dest);
+			glBindTexture(SourceTarget, 0);
+		}
+		return true;
+	}
+	else {
+
+		//
+		// RGBA only
+		//
+
+		GLenum status = 0;
+
+		// Create or resize a local OpenGL texture
+		CheckOpenGLTexture(m_TexID, GL_RGBA, width, height);
+
+		// Create a local fbo if not already
+		if (m_fbo == 0)
+			glGenFramebuffersEXT(1, &m_fbo);
+
+		// If texture ID is zero, assume the source texture is attached
+		// to the host fbo which is bound for read and write
+		if (SourceID == 0 && HostFBO > 0) {
+			// Bind our local fbo for draw only
+			glBindFramebufferEXT(GL_DRAW_FRAMEBUFFER_EXT, m_fbo);
+			// Source texture is already attached to point 0 for read
+		}
+		else {
+			// bind the local fbo for read and write
+			glBindFramebufferEXT(GL_FRAMEBUFFER_EXT, m_fbo);
+			// Read from attachment point 0
+			glReadBuffer(GL_COLOR_ATTACHMENT0_EXT);
+			// Attach the Source texture to point 0 for read
+			glFramebufferTexture2DEXT(GL_READ_FRAMEBUFFER_EXT, GL_COLOR_ATTACHMENT0_EXT, SourceTarget, SourceID, 0);
+		}
+
+		// Draw to attachment point 1
+		glDrawBuffer(GL_COLOR_ATTACHMENT1_EXT);
+
+		// Attach the texture we write into (the local texture) to attachment point 1
+		glFramebufferTexture2DEXT(GL_DRAW_FRAMEBUFFER_EXT, GL_COLOR_ATTACHMENT1_EXT, GL_TEXTURE_2D, m_TexID, 0);
+
+		// Check read/draw fbo for completeness
+		status = glCheckFramebufferStatusEXT(GL_FRAMEBUFFER_EXT);
+		if (status == GL_FRAMEBUFFER_COMPLETE_EXT) {
+			if (bInvert && m_bBLITavailable) {
+				// copy the source texture (0) to the local texture (1) while flipping upside down 
+				glBlitFramebufferEXT(0, 0, width, height, 0, height, width, 0, GL_COLOR_BUFFER_BIT, GL_NEAREST);
+				// Bind local fbo for read
+				glBindFramebufferEXT(GL_READ_FRAMEBUFFER_EXT, m_fbo);
+				// Read from attachment point 1
+				glReadBuffer(GL_COLOR_ATTACHMENT1_EXT);
+				// Read pixels from it
+				glPixelStorei(GL_PACK_ROW_LENGTH, pitch / 4); // row length in pixels
+				glReadPixels(0, 0, width, height, GL_RGBA, GL_UNSIGNED_BYTE, (GLvoid*)dest);
+				glPixelStorei(GL_PACK_ROW_LENGTH, 0);
+
+			}
+			else {
+				// No invert or no fbo blit extension
+				// Read from the source texture attachment point 0
+				// This will be the local fbo if a texture ID was passed in
+				// Pitch is destination line length in bytes. Divide by 4 to get the width in rgba pixels.
+				glPixelStorei(GL_PACK_ROW_LENGTH, pitch / 4); // row length in pixels
+				glReadPixels(0, 0, width, height, GL_RGBA, GL_UNSIGNED_BYTE, (GLvoid*)dest);
+				glPixelStorei(GL_PACK_ROW_LENGTH, 0);
+			}
+		}
+		else {
+			PrintFBOstatus(status);
+			glDrawBuffer(GL_COLOR_ATTACHMENT0_EXT);
+			glBindFramebufferEXT(GL_FRAMEBUFFER_EXT, HostFBO);
+			return false;
+		}
+
+		// restore the previous fbo - default is 0
+		glDrawBuffer(GL_COLOR_ATTACHMENT0_EXT);
+		glBindFramebufferEXT(GL_FRAMEBUFFER_EXT, HostFBO);
+	}
+
+	return true;
+
+} // end ReadTextureData
+
+
+//
+// COPY IMAGE PIXELS TO THE SHARED DX11 TEXTURE VIA STAGING TEXTURES
+// RGBA/RGB/BGRA/BGR supported
+//
+// GPU write is to DX11
+// Use staging texture to support RGBA/RGB
+//
+bool spoutGL::WriteDX11pixels(const unsigned char* pixels,
+	unsigned int width, unsigned int height, GLenum glFormat, bool bInvert)
+{
+	if (width != m_Width || height != m_Height || !pixels)
+		return false;
+
+	// if(!CheckStagingTextures(width, height, 1))
+	if (!CheckStagingTextures(width, height, 2))
+		return false;
+
+	// 1) pixels (RGBA or RGB) -> staging texture (RGBA) - CPU
+	// 2) staging texture -> DX11 sender texture (RGBA) CopyResource - GPU
+	//
+	// RGBA :
+	//   6.2 msec @ 3840 x 2160
+	//   1.6 msec @ 1920 x 1080
+	// RGBA Using UpdateSubresource (pixels > texture) instead of pixels > staging > texture
+	//   5.8 msec @ 3840 x 2160
+	//   1.5 msec @ 1920 x 1080
+	// RGB :
+	//   10 msec @ 3840 x 2160
+	//   2.7 msec @ 1920 x 1080
+	//
+	// Access the sender shared texture
+	if (frame.CheckTextureAccess(m_pSharedTexture)) {
+		// Map the staging texture and write pixels to it (CPU)
+		WritePixelData(pixels, m_pStaging[0], width, height, glFormat, bInvert);
+		// Copy from the staging texture to the sender shared texture (GPU)
+		spoutdx.GetDX11Context()->CopyResource(m_pSharedTexture, m_pStaging[0]);
+		spoutdx.GetDX11Context()->Flush();
+		frame.SetNewFrame();
+		frame.AllowTextureAccess(m_pSharedTexture);
+		return true;
+	}
+	return false;
+
+} // end WriteDX11pixels
+
+
+// Receive from a sender via DX11 staging textures to an rgba or rgb buffer of variable size
+// A new shared texture pointer (m_pSharedTexture) is retrieved if the sender changed
+bool spoutGL::ReadDX11pixels(unsigned char * pixels, unsigned int width, unsigned int height, GLenum glFormat, bool bInvert)
+{
+	if (!pixels)
+		return false;
+
+	if (!CheckStagingTextures(width, height, 2)) {
+		return false;
+	}
+
+	// No new frame, do not block
+	if (!frame.GetNewFrame())
+		return true;
+	
+	// If the sender has produced a new frame.
+	// Read from the sender GPU texture to CPU pixels via two staging textures
+
+	// Access the sender shared texture
+	if (frame.CheckTextureAccess(m_pSharedTexture)) {
+		m_Index = (m_Index + 1) % 2;
+		m_NextIndex = (m_Index + 1) % 2;
+		// Copy from the sender's shared texture to the first staging texture
+		spoutdx.GetDX11Context()->CopyResource(m_pStaging[m_Index], m_pSharedTexture);
+		// Map and read from the second while the first is occupied
+		ReadPixelData(m_pStaging[m_NextIndex], pixels, m_Width, m_Height, glFormat, bInvert);
+		// Allow access to the shared texture
+		frame.AllowTextureAccess(m_pSharedTexture);
+		return true;
+	}
+
+	return false;
+
+}
+
+
+// RGBA/RGB/BGRA/BGR supported
+bool spoutGL::WritePixelData(const unsigned char* pixels, ID3D11Texture2D* pStagingTexture,
+	unsigned int width, unsigned int height, GLenum glFormat, bool bInvert)
+{
+	if (!spoutdx.GetDX11Context() || !pStagingTexture || !pixels)
+		return false;
+
+	// glFormat = GL_RGB      0x1907
+	// glFormat = GL_RGBA     0x1908
+	// glFormat = GL_BGR_EXT  0x80E0
+	// glFormat = GL_BGRA_EXT 0x80E1
+	//
+	// m_dwFormat = 28 RGBA staging textures
+	// m_dwFormat = 87 BGRA staging textures
+
+	// Map the resource so we can access the pixels
+	D3D11_MAPPED_SUBRESOURCE mappedSubResource={};
+	// Make sure all commands are done before mapping the staging texture
+	spoutdx.GetDX11Context()->Flush();
+	// Map waits for GPU access
+	const HRESULT hr = spoutdx.GetDX11Context()->Map(pStagingTexture, 0, D3D11_MAP_READ, 0, &mappedSubResource);
+	if (SUCCEEDED(hr)) {
+		//
+		// Copy from the pixel buffer to the staging texture
+		//
+		// The shared texture format is BGRA or RGBA and the staging textures are the same format.
+		// If the texture format is BGRA and the receiving pixel buffer is RGBA/RGB or vice-versa,
+		// the data has to be converted from BGRA to RGBA/RGB or RGBA to BGRA/BGR during the pixel copy.
+		//
+		if (glFormat == GL_RGBA) { // RGBA pixel buffer
+			if (m_dwFormat == 28) // RGBA staging textures
+				spoutcopy.rgba2rgba((const void *)pixels, mappedSubResource.pData,
+					width, height, width*4, mappedSubResource.RowPitch, bInvert);
+			else
+				spoutcopy.rgba2bgra((const void *)pixels, mappedSubResource.pData, 
+					width, height, width*4, mappedSubResource.RowPitch, bInvert);
+		}
+		else if (glFormat == GL_BGRA_EXT) { // BGRA pixel buffer
+			if (m_dwFormat == 28)
+				spoutcopy.rgba2bgra((const void *)pixels, mappedSubResource.pData,
+					width, height, width * 4, mappedSubResource.RowPitch, bInvert);
+			else
+				spoutcopy.rgba2rgba((const void *)pixels, mappedSubResource.pData,
+					width, height, width*4, mappedSubResource.RowPitch, bInvert);
+		}
+		else if (glFormat == GL_RGB) { // RGB pixel buffer
+			if (m_dwFormat == 28)
+				spoutcopy.rgb2rgba((const void *)pixels, mappedSubResource.pData, 
+					width, height, mappedSubResource.RowPitch, bInvert);
+			else
+				spoutcopy.rgb2bgra((const void *)pixels, mappedSubResource.pData,
+					width, height, mappedSubResource.RowPitch, bInvert);
+		}
+		else if (glFormat == GL_BGR_EXT) { // BGR pixel buffer
+			if (m_dwFormat == 28)
+				spoutcopy.bgr2rgba((const void *)pixels, mappedSubResource.pData,
+					width, height, mappedSubResource.RowPitch, bInvert);
+			else
+				spoutcopy.rgb2rgba((const void *)pixels, mappedSubResource.pData,
+					width, height, mappedSubResource.RowPitch, bInvert);
+		}
+		spoutdx.GetDX11Context()->Unmap(pStagingTexture, 0);
+
+		return true;
+
+	} // endif DX11 map OK
+
+	return false;
+
+} // end WritePixelData
+
+
+//
+// COPY FROM A DX11 STAGING TEXTURE TO A USER RGBA/RGB/BGR PIXEL BUFFER
+//
+bool spoutGL::ReadPixelData(ID3D11Texture2D* pStagingTexture, unsigned char* pixels,
+	unsigned int width, unsigned int height, GLenum glFormat, bool bInvert)
+{
+	if (!spoutdx.GetDX11Context() || !pStagingTexture || !pixels)
+		return false;
+
+	// glFormat = GL_RGB      0x1907
+	// glFormat = GL_RGBA     0x1908
+	// glFormat = GL_BGR_EXT  0x80E0
+	// glFormat = GL_BGRA_EXT 0x80E1
+	//
+	// m_dwFormat = 28 RGBA staging textures
+	// m_dwFormat = 87 BGRA staging textures
+
+	// Map the resource so we can access the pixels
+	D3D11_MAPPED_SUBRESOURCE mappedSubResource={};
+	// Make sure all commands are done before mapping the staging texture
+	spoutdx.GetDX11Context()->Flush();
+	// Map waits for GPU access
+	const HRESULT hr = spoutdx.GetDX11Context()->Map(pStagingTexture, 0, D3D11_MAP_READ, 0, &mappedSubResource);
+	if (SUCCEEDED(hr)) {
+		//
+		// Copy from staging texture to the pixel buffer
+		//
+		// The shared texture format is BGRA or RGBA and the staging textures are the same format.
+		// If the texture format is BGRA and the receiving pixel buffer is RGBA/RGB or vice-versa,
+		// the data has to be converted from BGRA to RGBA/RGB or RGBA to BGRA/BGR during the pixel copy.
+		//
+		if (glFormat == GL_RGBA) { // RGBA pixel buffer
+			if (m_dwFormat == 28) // RGBA staging textures
+				spoutcopy.rgba2rgba(mappedSubResource.pData, pixels, width, height, mappedSubResource.RowPitch, bInvert);
+			else
+				spoutcopy.rgba2bgra(mappedSubResource.pData, pixels, width, height, mappedSubResource.RowPitch, bInvert);
+		}
+		else if (glFormat == GL_BGRA_EXT) { // BGRA pixel buffer
+			if (m_dwFormat == 28)
+				spoutcopy.rgba2bgra(mappedSubResource.pData, pixels, width, height, mappedSubResource.RowPitch, bInvert);
+			else
+				spoutcopy.rgba2rgba(mappedSubResource.pData, pixels, width, height, mappedSubResource.RowPitch, bInvert);
+		}
+		else if (glFormat == GL_RGB) { // RGB pixel buffer
+			if (m_dwFormat == 28)
+				spoutcopy.rgba2rgb(mappedSubResource.pData, pixels, m_Width, m_Height, mappedSubResource.RowPitch, bInvert);
+			else
+				spoutcopy.rgba2bgr(mappedSubResource.pData, pixels, m_Width, m_Height, mappedSubResource.RowPitch, bInvert);
+		}
+		else if (glFormat == GL_BGR_EXT) { // BGR pixel buffer
+			if (m_dwFormat == 28)
+				spoutcopy.rgba2bgr(mappedSubResource.pData, pixels, m_Width, m_Height, mappedSubResource.RowPitch, bInvert);
+			else
+				spoutcopy.rgba2rgb(mappedSubResource.pData, pixels, m_Width, m_Height, mappedSubResource.RowPitch, bInvert);
+		}
+
+		spoutdx.GetDX11Context()->Unmap(pStagingTexture, 0);
+
+		return true;
+	} // endif DX11 map OK
+
+	return false;
+
+} // end ReadPixelData
+
+
+// Create class staging textures for changed size or if they do not exist yet
+// Two are available but only one can be allocated to save memory
+// Format is the same as the shared texture - m_dwFormat
+bool spoutGL::CheckStagingTextures(unsigned int width, unsigned int height, int nTextures)
+{
+	if (!spoutdx.GetDX11Device()) {
+		return false;
+	}
+
+	D3D11_TEXTURE2D_DESC desc = { 0 };
+
+	if (m_pStaging[0]) {
+
+		// Get the size to test for change
+		m_pStaging[0]->GetDesc(&desc);
+		if (desc.Width != width || desc.Height != height) {
+			// Staging textures must not be mapped before release
+			if (m_pStaging[0]) spoutdx.ReleaseDX11Texture(spoutdx.GetDX11Device(), m_pStaging[0]);
+			if (m_pStaging[1]) spoutdx.ReleaseDX11Texture(spoutdx.GetDX11Device(), m_pStaging[1]);
+			m_pStaging[0] = nullptr;
+			m_pStaging[1] = nullptr;
+
+			// Flush context to avoid deferred release
+			spoutdx.Flush();
+
+			// Drop through to create new textures
+		}
+		else {
+			return true;
+		}
+	}
+
+	if (!spoutdx.CreateDX11StagingTexture(spoutdx.GetDX11Device(), width, height, (DXGI_FORMAT)m_dwFormat, &m_pStaging[0]))
+		return false;
+
+	if (nTextures > 1) {
+		if (!spoutdx.CreateDX11StagingTexture(spoutdx.GetDX11Device(), width, height, (DXGI_FORMAT)m_dwFormat, &m_pStaging[1]))
+			return false;
+	}
+
+	// Update class width and height
+	m_Width = width;
+	m_Height = height;
+
+	// Reset staging texture index
+	m_Index = 0;
+	m_NextIndex = 0;
+
+	// Also reset PBO index
+	PboIndex = 0;
+	NextPboIndex = 0;
+
+	// Did something go wrong somehow
+	if (!m_pStaging[0])
+		return false;
+	if (nTextures > 1 && !m_pStaging[1])
+		return false;
+
+	return true;
+
+} // end CheckStagingTextures
+
+
+//
+// Memoryshare functions - receive only
+//
+
+//
+// Read rgba shared memory to texture pixel data
+//
+bool spoutGL::ReadMemoryTexture(const char* sendername, GLuint TexID, GLuint TextureTarget,
+	unsigned int width, unsigned int height, bool bInvert, GLuint HostFBO)
+{
+	// Open a shared memory map if it not already
+	if (!memoryshare.Name()) {
+		// Create a name for the map from the sender name
+		std::string namestring = sendername;
+		namestring += "_map";
+		// Try to open the shared memory map.
+		if (!memoryshare.Open(namestring.c_str())) {
+			// No map
+			return false;
+		}
+		SpoutLogNotice("SpoutSharedMemory::ReadMemoryTexture - opened sender memory map [%s]", memoryshare.Name());
+	}
+
+	const char* pBuffer = memoryshare.Lock();
+	if (!pBuffer) {
+		SpoutLogError("SpoutSharedMemory::ReadMemoryTexture - no buffer lock");
+		return false;
+	}
+
+	bool bRet = true; // Error only if pixel read fails
+
+	// Query a new frame and read pixels while the buffer is locked
+	if (bInvert) {
+		// Create or resize a local OpenGL texture
+		CheckOpenGLTexture(m_TexID, GL_RGBA, width, height);
+		// Read the memory pixels into it
+		glBindTexture(GL_TEXTURE_2D, m_TexID);
+		glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, width, height, GL_BGRA_EXT, GL_UNSIGNED_BYTE, (GLvoid *)pBuffer);
+		glBindTexture(GL_TEXTURE_2D, 0);
+		// Copy to the user texture, inverting at the same time
+		bRet = CopyTexture(m_TexID, GL_TEXTURE_2D, TexID, TextureTarget, width, height, true, HostFBO);
+	}
+	else {
+		// No invert - copy memory pixels directly to the user texture
+		glBindTexture(TextureTarget, TexID);
+		glTexSubImage2D(TextureTarget, 0, 0, 0, width, height, GL_RGBA, GL_UNSIGNED_BYTE, (GLvoid *)pBuffer);
+		glBindTexture(TextureTarget, 0);
+	}
+
+	memoryshare.Unlock();
+
+	return bRet;
+
+}
+
+//
+// Read shared memory to image pixels
+//
+bool spoutGL::ReadMemoryPixels(const char* sendername, unsigned char* pixels,
+	unsigned int width, unsigned int height, GLenum glFormat, bool bInvert)
+{
+	if (!pixels || glFormat != GL_RGBA) {
+		SpoutLogError("spoutGLDXinterop::ReadMemoryPixels - no data or incorrect format");
+		return false;
+	}
+
+	// No new frame, do not block
+	if (!frame.GetNewFrame())
+		return true;
+
+	// Open a shared memory map if it not already
+	if (!memoryshare.Name()) {
+		// Create a name for the map from the sender name
+		std::string namestring = sendername;
+		namestring += "_map";
+		// Open the shared memory map.
+		if (!memoryshare.Open(namestring.c_str())) {
+			return false;
+		}
+		SpoutLogNotice("SpoutSharedMemory::ReadMemoryPixels - opened sender memory map [%s]", memoryshare.Name());
+	}
+
+	const char* pBuffer = memoryshare.Lock();
+	if (!pBuffer) {
+		SpoutLogError("SpoutSharedMemory::ReadMemoryPixels - no buffer lock");
+		return false;
+	}
+
+	// Query a new frame and read pixels while the buffer is locked
+	// Read pixels from shared memory
+	spoutcopy.CopyPixels((unsigned char*)pBuffer, pixels, width, height, glFormat, bInvert);
+
+	memoryshare.Unlock();
+
+	return true;
+
+}
+
+//
+// Write image pixels to shared memory
+//
+bool spoutGL::WriteMemoryPixels(const char *sendername, const unsigned char* pixels, unsigned int width, unsigned int height, GLenum glFormat, bool bInvert)
+{
+	if (!pixels || glFormat != GL_RGBA) {
+		SpoutLogError("spoutGLDXinterop::WriteMemoryPixels - no data or incorrect format");
+		return false;
+	}
+
+	// Create a shared memory map if it does not exist yet
+	char* pBuffer = nullptr;
+	if (memoryshare.Size() == 0) {
+		// Create a name for the map from the sender name
+		std::string namestring = sendername;
+		namestring += "_map";
+		if (memoryshare.Create(sendername, width*4*height) != SPOUT_CREATE_FAILED) {
+			SpoutLogError("SpoutSharedMemory::WriteMemoryPixels - could not create shared memory");
+			return false;
+		}
+		pBuffer = memoryshare.Lock();
+		if (!pBuffer) {
+			SpoutLogError("SpoutSharedMemory::WriteMemoryPixels - no buffer lock");
+			return false;
+		}
+	}
+
+	// Write pixel data to shared memory
+	spoutcopy.CopyPixels(pixels, (unsigned char *)pBuffer, width, height, glFormat, bInvert);
+
+	memoryshare.Unlock();
+
+	return true;
+
+}
+
+//
+// Directx 11
+//
+
+//---------------------------------------------------------
+bool spoutGL::OpenDirectX11(ID3D11Device* pDevice)
+{
+	return spoutdx.OpenDirectX11(pDevice);
+}
+
+//---------------------------------------------------------
+ID3D11Device* spoutGL::GetDX11Device()
+{
+	return spoutdx.GetDX11Device();
+}
+
+//---------------------------------------------------------
+ID3D11DeviceContext* spoutGL::GetDX11Context()
+{
+	return spoutdx.GetDX11Context();
+}
+
+//---------------------------------------------------------
+void spoutGL::CleanupDirectX()
+{
+	// DirectX 9 not supported >= 2.007
+	CleanupDX11();
+}
+
+//---------------------------------------------------------
+void spoutGL::CleanupDX11()
+{
+	if (spoutdx.GetDX11Device()) {
+
+		SpoutLogNotice("spoutGL::CleanupDX11()");
+
+		// Reference count warnings are in the SpoutDirectX class
+
+		// Release linked DirectX shared texture
+		if (m_pSharedTexture) {
+			SpoutLogNotice("    Releasing shared texture");
+			// Release interop before releasing the texture
+			// Requires openGL context
+			if (m_hInteropDevice && m_hInteropObject) {
+				if (!CleanupInterop()) {
+					SpoutLogWarning("    GL/DX Interop could not be released");
+				}
+			}
+			spoutdx.ReleaseDX11Texture(spoutdx.GetDX11Device(), m_pSharedTexture);
+		}
+
+		// Important to set pointer to NULL or it will crash if released again
+		m_pSharedTexture = nullptr;
+
+		// Re-set shared texture handle
+		m_dxShareHandle = nullptr;
+
+		// Release staging texture if they have been used
+		if (m_pStaging[0]) spoutdx.ReleaseDX11Texture(spoutdx.GetDX11Device(), m_pStaging[0]);
+		if (m_pStaging[1]) spoutdx.ReleaseDX11Texture(spoutdx.GetDX11Device(), m_pStaging[1]);
+		m_pStaging[0] = nullptr;
+		m_pStaging[1] = nullptr;
+		m_Index = 0;
+		m_NextIndex = 0;
+
+		// Flush context to avoid deferred release
+		spoutdx.Flush();
+
+		// 12.11.18 - To avoid memory leak with dynamic objects
+		//            they must always be freed, not only on exit.
+		//            Device recreated for a new sender.
+		// Releases immediate context and device in the SpoutDirectX class
+		// spoutdx.GetDX11Context() and spoutdx.GetDX11Device() are copies of these
+		spoutdx.CloseDirectX11();
+
+	}
+	else {
+		SpoutLogNotice("spoutGL::CleanupDX11() - device closed");
+	}
+
+}
+
+//
+// Extensions and availability
+//
+
+//---------------------------------------------------------
+bool spoutGL::LoadGLextensions()
+{
+	// Return if already loaded
+	if (m_caps > 0) {
+		SpoutLogNotice("spoutGL::LoadGLextensions - already loaded");
+		return true;
+	}
+
+	// Needs an OpenGL context
+	if (!wglGetCurrentContext()) {
+		SpoutLogWarning("spoutGL::LoadGLextensions - no OpenGL context");
+		return false;
+	}
+
+	m_bFBOavailable = false;
+	m_bGLDXavailable = false;
+	m_bBLITavailable = false;
+	m_bSWAPavailable = false;
+	m_bBGRAavailable = false;
+	m_bCOPYavailable = false;
+	m_bCONTEXTavailable = false;
+
+	m_caps = loadGLextensions(); // in spoutGLextensions
+
+	if (m_caps == 0) {
+		SpoutLogError("spoutGL::LoadGLextensions failed");
+		m_bPBOavailable = false;
+		return false;
+	}
+
+	if (m_caps & GLEXT_SUPPORT_FBO)
+		m_bFBOavailable = true;
+
+	// FBO not available is terminal
+	if (!m_bFBOavailable) {
+		SpoutLogError("spoutGL::LoadGLextensions - no FBO extensions available");
+		m_bPBOavailable = false; // No PBO support either - over-ride user selection
+		return false;
+	}
+
+	if (m_caps & GLEXT_SUPPORT_NVINTEROP) m_bGLDXavailable = true; // Interop needed for texture sharing
+	if (m_caps & GLEXT_SUPPORT_FBO_BLIT)  m_bBLITavailable = true;
+	if (m_caps & GLEXT_SUPPORT_SWAP)      m_bSWAPavailable = true;
+	if (m_caps & GLEXT_SUPPORT_BGRA)      m_bBGRAavailable = true;
+	if (m_caps & GLEXT_SUPPORT_COPY)      m_bCOPYavailable = true;
+	if (m_caps & GLEXT_SUPPORT_CONTEXT)   m_bCONTEXTavailable = true;
+
+	// Test PBO availability unless user has checked buffering OFF (sets m_bPBOavailable false)
+	// m_bPBOavailable can also be set by the application with SetBufferMode()
+	if (m_bPBOavailable) { // User selected buffering
+		if (!(m_caps & GLEXT_SUPPORT_PBO))
+			m_bPBOavailable = false;
+	}
+
+	// Show status
+	if (!m_bPBOavailable) { // User did not select buffering
+		if (!(m_caps & GLEXT_SUPPORT_PBO))
+			SpoutLogWarning("spoutGL::LoadGLextensions - pbo extensions not available");
+		else
+			SpoutLogWarning("spoutGL::LoadGLextensions - pbo functions disabled by settings");
+	}
+	else if (!m_bGLDXavailable)
+		SpoutLogWarning("spoutGL::LoadGLextensions - interop extensions not available");
+	else if (!m_bBLITavailable)
+		SpoutLogWarning("spoutGL::LoadGLextensions - fbo blit extension not available");
+	else if (!m_bSWAPavailable)
+		SpoutLogWarning("spoutGL::LoadGLextensions - sync control extensions not available");
+	else if (!m_bBGRAavailable)
+		SpoutLogWarning("spoutGL::LoadGLextensions - bgra extension not available");
+	else if (!m_bCOPYavailable)
+		SpoutLogWarning("spoutGL::LoadGLextensions - copy extensions not available");
+	else if (!m_bCONTEXTavailable)
+		SpoutLogWarning("spoutGL::LoadGLextensions - context extension not available");
+	else
+		SpoutLogNotice("spoutGL::LoadGLextensions - all extensions available");
+
+	m_bExtensionsLoaded = true;
+
+	return true;
+}
+
+//---------------------------------------------------------
+bool spoutGL::IsGLDXavailable()
+{
+	return m_bGLDXavailable;
+}
+
+//---------------------------------------------------------
+bool spoutGL::IsBLITavailable()
+{
+	return m_bBLITavailable;
+}
+
+//---------------------------------------------------------
+bool spoutGL::IsSWAPavailable()
+{
+	return m_bSWAPavailable;
+}
+
+//---------------------------------------------------------
+bool spoutGL::IsBGRAavailable()
+{
+	return m_bBGRAavailable;
+}
+
+//---------------------------------------------------------
+bool spoutGL::IsCOPYavailable()
+{
+	return m_bCOPYavailable;
+}
+
+//---------------------------------------------------------
+bool spoutGL::IsPBOavailable()
+{
+	return m_bPBOavailable;
+}
+
+//---------------------------------------------------------
+bool spoutGL::IsCONTEXTavailable()
+{
+	return m_bCONTEXTavailable;
+}
+
+// 
+// Legacy OpenGL functions
+//
+
+#ifdef legacyOpenGL
+
+//---------------------------------------------------------
+void spoutGL::SaveOpenGLstate(unsigned int width, unsigned int height, bool bFitWindow)
+{
+	float dim[4]={};
+	float vpScaleX, vpScaleY, vpWidth, vpHeight;
+	int vpx, vpy;
+
+	// save texture state, client state, etc.
+	glPushAttrib(GL_ALL_ATTRIB_BITS);
+	glPushClientAttrib(GL_CLIENT_ALL_ATTRIB_BITS);
+
+	glMatrixMode(GL_TEXTURE);
+	glPushMatrix();
+	glLoadIdentity();
+
+	glPushAttrib(GL_TRANSFORM_BIT);
+
+	// find the current viewport dimensions in order to scale to the aspect ratio required
+	glGetFloatv(GL_VIEWPORT, dim);
+
+	// Fit to window
+	if (bFitWindow) {
+		// Scale both width and height to the current viewport size
+		vpScaleX = dim[2] / (float)width;
+		vpScaleY = dim[3] / (float)height;
+		vpWidth = (float)width  * vpScaleX;
+		vpHeight = (float)height * vpScaleY;
+		vpx = vpy = 0;
+	}
+	else {
+		// Preserve aspect ratio of the sender
+		// and fit to the width or the height
+		vpWidth = dim[2]={};
+		vpHeight = ((float)height / (float)width)*vpWidth;
+		if (vpHeight > dim[3]) {
+			vpHeight = dim[3]={};
+			vpWidth = ((float)width / (float)height)*vpHeight;
+		}
+		vpx = (int)(dim[2] - vpWidth) / 2;;
+		vpy = (int)(dim[3] - vpHeight) / 2;
+	}
+
+	glViewport((int)vpx, (int)vpy, (int)vpWidth, (int)vpHeight);
+
+	glMatrixMode(GL_PROJECTION);
+	glPushMatrix();
+	glLoadIdentity(); // reset the current matrix back to its default state
+	glOrtho(-1.0, 1.0, -1.0, 1.0, -1.0f, 1.0f);
+
+	glMatrixMode(GL_MODELVIEW);
+	glPushMatrix();
+	glLoadIdentity();
+}
+
+
+void spoutGL::RestoreOpenGLstate()
+{
+	glMatrixMode(GL_MODELVIEW);
+	glPopMatrix();
+
+	glMatrixMode(GL_PROJECTION);
+	glPopMatrix();
+
+	glPopAttrib();
+
+	glMatrixMode(GL_TEXTURE);
+	glPopMatrix();
+
+	glPopClientAttrib();
+	glPopAttrib();
+
+}
+
+#endif
+
+//
+// Utility
+//
+
+//---------------------------------------------------------
+// Given a DeviceKey string from a DisplayDevice
+// read all the information about the adapter.
+// Only used by this class.
+bool spoutGL::OpenDeviceKey(const char* key, int maxsize, char* description, char* version)
+{
+	if (!key)
+		return false;
+
+	// Extract the subkey from the DeviceKey string
+	HKEY hRegKey = nullptr;
+	DWORD dwSize = 0;
+	DWORD dwKey = 0;
+
+	char output[256]={};
+	strcpy_s(output, 256, key);
+	const char *found = strstr(output, "System");
+	if (!found)
+		return false;
+	std::string SubKey = found;
+
+	// Convert all slash to double slash using a C++ string function
+	// to get subkey string required to extract registry information
+	for (unsigned int i = 0; i < SubKey.length(); i++) {
+		if (SubKey.at(i) == '\\') {
+			SubKey.insert(i, 1, '\\');
+			++i; // Skip inserted char
+		}
+	}
+
+	// Open the key to find the adapter details
+	if (RegOpenKeyExA(HKEY_LOCAL_MACHINE, SubKey.c_str(), NULL, KEY_READ, &hRegKey) == 0) {
+
+		dwSize = 256;
+		// Adapter name
+		if (RegQueryValueExA(hRegKey, "DriverDesc", NULL, &dwKey, (BYTE*)output, &dwSize) == 0) {
+			strcpy_s(description, (rsize_t)maxsize, output);
+		}
+		if (RegQueryValueExA(hRegKey, "DriverVersion", NULL, &dwKey, (BYTE*)output, &dwSize) == 0) {
+			// Find the last 6 characters of the version string then
+			// convert to a float and multiply to get decimal in the right place
+			sprintf_s(output, 256, "%5.2f", atof(output + strlen(output) - 6)*100.0);
+			strcpy_s(version, (rsize_t)maxsize, output);
+		} // endif DriverVersion
+		RegCloseKey(hRegKey);
+	} // endif RegOpenKey
+
+	return true;
+}
+
+//---------------------------------------------------------
+void spoutGL::trim(char* s) {
+	
+	char* p = s;
+	if (!p) return;
+
+	int l = (int)strlen(p);
+
+	while (isspace(p[l - 1])) p[--l] = 0;
+	while (*p && isspace(*p)) ++p, --l;
+
+	// Casting first avoids warning C26451: Arithmetic overflow with VS2022 code review
+	// https://docs.microsoft.com/en-us/visualstudio/code-quality/c26451
+	const size_t l1 = (size_t)l + 1;
+	memmove(s, p, l1);
+}
+
+//
+// Errors
+//
+
+// Perform diagnostics and write the results to a log file
+void spoutGL::DoDiagnostics(const char *error = nullptr)
+{
+	// Create a log file using the executable or dll name
+	// (See SpoutUtils GetExeName)
+	char logname[MAX_PATH]={};
+	strcpy_s(logname, MAX_PATH, GetExeName().c_str());
+	strcat_s(logname, MAX_PATH, "_diagnostics.log");
+
+	// Show a line break for any existing log
+	SpoutLogNotice("\n");
+
+	// Create the diagnostic log file
+	EnableSpoutLogFile(logname);
+
+	// Show the error if provided
+	if(error)
+		SpoutLogNotice("spoutGL::DoDiagnostics %s", error);
+	else
+		SpoutLogNotice("spoutGL::DoDiagnostics");
+
+	// Get the Spout version as a single number
+	// For example : 2.006 = 2006, 2.007 = 2007, 2.007.009 = 2007009
+	const int spoutVersion = GetSpoutVersion();
+	if (spoutVersion > 0) {
+		if (spoutVersion <= 2007) {
+			SpoutLogNotice("Spout Version - 2.00%1d", (spoutVersion - 2000));
+		}
+		else {
+			SpoutLogNotice("Spout Version - %s", GetSDKversion().c_str());
+		}
+	}
+	else if (spoutVersion == 0) {
+		SpoutLogNotice("Spout Version - 2.004 or earlier");
+	}
+
+	// Check DirectX device
+	if (!GetDX11Device()) {
+		SpoutLogWarning("DirectX 11 device not available");
+	}
+	else {
+		SpoutLogNotice("DirectX 11 device available");
+	}
+
+	//
+	// Identify the computer and graphics systems
+	//
+
+	// Computer/laptop detection
+	char computername[16]={};
+	DWORD nchars = 16;
+	GetComputerNameA(computername, &nchars);
+	if (IsLaptop()) SpoutLogNotice("Laptop system (%s)", computername);
+	else SpoutLogNotice("Desktop system (%s)", computername);
+
+	// Check the vendor of the primary GPU currently in use
+	SpoutLogNotice("Graphics : %s", (char*)glGetString(GL_VENDOR));
+	// Find the primary adapter and display names
+	char adapter[256]={};
+	char display[256]={};
+	spoutdx.GetAdapterInfo(adapter, display, 256);
+	if (adapter && adapter[0]) {
+		trim(adapter);
+		SpoutLogNotice("%s", adapter);
+	}
+
+	// Secondary adapter
+	const int nadapters = spoutdx.GetNumAdapters();
+	if (nadapters > 1) {
+		spoutdx.GetAdapterName(1, adapter, 256);
+		SpoutLogNotice("Secondary : %s", adapter);
+	}
+
+	// The display output
+	if (display && display[0]) {
+		trim(display);
+		SpoutLogNotice("Display : %s", display);
+	}
+
+	// If DirectX is OK, check for availabilty of the GL/DX extensions.
+	// The NV_DX_interop extensions will fail if the graphics driver does not support them
+	if (GetDX11Device()) {
+		if (wglGetProcAddress("wglDXOpenDeviceNV")) { // extensions can be loaded
+			SpoutLogNotice("NV_DX_interop extensions available");
+			// Load the extensions (returns true if already loaded)
+			if (!LoadGLextensions()) {
+				SpoutLogWarning("OpenGL extensions failed to load");
+				SpoutLogWarning("    Graphics not texture share compatible");
+			}
+			else {
+				// It is possible that extensions load OK but that the GL/DX interop functions fail.
+				// This has been noted on dual graphics machines with the NVIDIA Optimus driver.
+				// Check OpenGL GL/DX extension functionsand create an interop device for success
+				if (GetDX11Device()) {
+					// Test compatibility
+					// Repeat the test if already done
+					m_bGLDXdone = false;
+					if (!GLDXready()) {
+						SpoutLogWarning("OpenGL/DX11 texture sharing failed");
+					}
+					else {
+						SpoutLogNotice("OpenGL/DX11 texture sharing succeeded");
+					}
+				}
+				else {
+					SpoutLogWarning("DX11 initialization failed");
+				}
+
+				// Show compatibility
+				if (IsGLDXready()) {
+					SpoutLogNotice("Compatible for OpenGL texture sharing");
+				}
+				else {
+					SpoutLogWarning("Not compatible for OpenGL texture sharing");
+					SpoutLogWarning("    CPU system memory used as backup");
+				}
+			} // loaded extensions OK
+		}
+		else {
+			// The extensions required for texture access are not available.
+			SpoutLogWarning("NV_DX_interop extensions not supported");
+			SpoutLogWarning("    Graphics not texture share compatible");
+		}
+		
+	}
+
+	SpoutLogNotice("End Diagnostics");
+	if(!GetSpoutLogPath().empty())
+		SpoutLogNotice("%s\n", GetSpoutLogPath().c_str());
+
+	// Close the log file
+	// Console logging remains for testing
+	DisableSpoutLogFile();
+
+}
+
+
+
+void spoutGL::PrintFBOstatus(GLenum status)
+{
+	char tmp[256]={};
+	sprintf_s(tmp, 256, "FBO status error %u (0x%.7X) - ", status, status);
+	if (status == GL_FRAMEBUFFER_UNSUPPORTED_EXT)
+		strcat_s(tmp, 256, "GL_FRAMEBUFFER_UNSUPPORTED_EXT");
+	else if (status == GL_FRAMEBUFFER_INCOMPLETE_ATTACHMENT_EXT)
+		strcat_s(tmp, 256, "GL_FRAMEBUFFER_INCOMPLETE_ATTACHMENT_EXT");
+	else if (status == GL_FRAMEBUFFER_INCOMPLETE_MISSING_ATTACHMENT_EXT)
+		strcat_s(tmp, 256, "GL_FRAMEBUFFER_INCOMPLETE_MISSING_ATTACHMENT_EXT");
+	else if (status == GL_FRAMEBUFFER_INCOMPLETE_DIMENSIONS_EXT)
+		strcat_s(tmp, 256, "GL_FRAMEBUFFER_INCOMPLETE_DIMENSIONS_EXT - width-height problems?");
+	else if (status == GL_FRAMEBUFFER_INCOMPLETE_FORMATS_EXT)
+		strcat_s(tmp, 256, "GL_FRAMEBUFFER_INCOMPLETE_FORMATS_EXT");
+	else if (status == GL_FRAMEBUFFER_INCOMPLETE_DRAW_BUFFER_EXT)
+		strcat_s(tmp, 256, "GL_FRAMEBUFFER_INCOMPLETE_DRAW_BUFFER_EXT");
+	else if (status == GL_FRAMEBUFFER_INCOMPLETE_READ_BUFFER_EXT)
+		strcat_s(tmp, 256, "GL_FRAMEBUFFER_INCOMPLETE_READ_BUFFER_EXT");
+	else if (status == GL_INVALID_ENUM)
+		strcat_s(tmp, 256, "GL_INVALID_ENUM");
+	else if (status == GL_FRAMEBUFFER_UNDEFINED_EXT)
+		strcat_s(tmp, 256, "GL_FRAMEBUFFER_UNDEFINED");
+	// else if (status == GL_FRAMEBUFFER_INCOMPLETE_MULTISAMPLE_EXT)
+		// strcat_s(tmp, 256, "GL_FRAMEBUFFER_INCOMPLETE_MULTISAMPLE_EXT\n");
+	if (status != GL_FRAMEBUFFER_COMPLETE_EXT) {
+		strcat_s(tmp, 256, "Unknown status code");
+		// Additionally, if an error occurs, zero is returned.
+		SpoutLogError("%s", tmp);
+	}
+	// printf("  PrintFBOstatus(%d) - %s\n",status, tmp);
+	GLerror();
+
+}
+
+bool spoutGL::GLerror() {
+	GLenum err = GL_NO_ERROR;
+	int nError = 0;
+	bool bError = false;
+	while ((err = glGetError()) != GL_NO_ERROR) {
+		SpoutLogError("    GLerror (%d) - OpenGL error = %u (0x%.7X)", nError, err, err);
+		// printf("GLerror (%d) - OpenGL error = %u (0x%.7X)\n", nError, err, err);
+		nError++;
+		bError = true;
+#ifdef USE_GLEW
+		// gluErrorString needs Glu.h and glu32.lib (or glew)
+		printf("GL error (%d) = %d (0x%.7X) %s\n", nError, err, err, gluErrorString(err));
+#endif
+	}
+	return bError;
+}
+
+//
+// Group: User registry settings recorded by "SpoutSettings"
+//
+// User settings are retrieved in constructor and can be 
+// set for the application (except max senders which must be global)
+//
+
+//---------------------------------------------------------
+// Function: GetBufferMode
+// Get user buffering mode
+//
+bool spoutGL::GetBufferMode()
+{
+	return m_bPBOavailable;
+}
+
+//---------------------------------------------------------
+// Function: SetBufferMode
+// Set application buffering mode
+void spoutGL::SetBufferMode(bool bActive)
+{
+	if (m_bExtensionsLoaded) {
+		if (bActive) {
+			if (m_caps & GLEXT_SUPPORT_PBO) {
+				m_bPBOavailable = true;
+			}
+		}
+		else {
+			m_bPBOavailable = false;
+		}
+	}
+	else {
+		m_bPBOavailable = false;
+	}
+}
+
+//---------------------------------------------------------
+// Function: GetBuffers
+// Get user number of pixel buffers
+int spoutGL::GetBuffers()
+{
+	return m_nBuffers;
+}
+
+//---------------------------------------------------------
+// Function: SetBuffers
+// Set application number of pixel buffers
+void spoutGL::SetBuffers(int nBuffers)
+{
+	m_nBuffers = nBuffers;
+}
+
+//---------------------------------------------------------
+// Function: GetMaxSenders
+// Get user Maximum senders allowed
+int spoutGL::GetMaxSenders()
+{
+	return sendernames.GetMaxSenders();
+}
+
+//---------------------------------------------------------
+// Function: SetMaxSenders
+// Set user Maximum senders allowed
+void spoutGL::SetMaxSenders(int maxSenders)
+{
+	// Setting must be global for all applications
+	sendernames.SetMaxSenders(maxSenders);
+}
+
+//
+// Group: Retained for 2.006 compatibility
+//
+
+//---------------------------------------------------------
+// Function: GetDX9
+// Get user DX9 mode
+bool spoutGL::GetDX9()
+{
+	DWORD dwDX9 = 0;
+	ReadDwordFromRegistry(HKEY_CURRENT_USER, "Software\\Leading Edge\\Spout", "DX9", &dwDX9);
+	return (dwDX9 == 1);
+}
+
+//---------------------------------------------------------
+// Function: SetDX9
+// Set user DX9 mode
+bool spoutGL::SetDX9(bool bDX9)
+{
+	return WriteDwordToRegistry(HKEY_CURRENT_USER, "Software\\Leading Edge\\Spout", "DX9", (DWORD)bDX9);
+}
+
+//---------------------------------------------------------
+// Function: GetMemoryShareMode
+// Get user memory share mode
+bool spoutGL::GetMemoryShareMode()
+{
+	DWORD dwMem = 0;
+	ReadDwordFromRegistry(HKEY_CURRENT_USER, "Software\\Leading Edge\\Spout", "MemoryShare", &dwMem);
+	return (dwMem == 1);
+}
+
+//---------------------------------------------------------
+// Function: SetMemoryShareMode
+// Set user memory share mode
+bool spoutGL::SetMemoryShareMode(bool bMem)
+{
+	return WriteDwordToRegistry(HKEY_CURRENT_USER, "Software\\Leading Edge\\Spout", "MemoryShare", (DWORD)bMem);
+}
+
+//---------------------------------------------------------
+// Function: GetCPUmode
+// Get user CPU mode
+bool spoutGL::GetCPUmode()
+{
+	DWORD dwCpu = 0;
+	ReadDwordFromRegistry(HKEY_CURRENT_USER, "Software\\Leading Edge\\Spout", "CPU", &dwCpu);
+	return (dwCpu == 1);
+}
+
+//---------------------------------------------------------
+// Function: SetCPUmode
+// Set user CPU mode
+bool spoutGL::SetCPUmode(bool bCPU)
+{
+	return WriteDwordToRegistry(HKEY_CURRENT_USER, "Software\\Leading Edge\\Spout", "CPU", (DWORD)bCPU);
+}
+
+// Function: GetShareMode
+// Get user share mode
+//  0 - texture, 1 - memory, 2 - CPU
+int spoutGL::GetShareMode()
+{
+	DWORD dwMem = 0;
+	DWORD dwCPU = 0;
+	ReadDwordFromRegistry(HKEY_CURRENT_USER, "Software\\Leading Edge\\Spout", "MemoryShare", &dwMem);
+	ReadDwordFromRegistry(HKEY_CURRENT_USER, "Software\\Leading Edge\\Spout", "CPU", &dwCPU);
+
+	if (dwCPU > 0) {
+		return 2;
+	}
+	if (dwMem > 0) {
+		return 1;
+	}
+
+	// 0 : Texture share default
+	return 0;
+
+}
+
+//---------------------------------------------------------
+// Function: SetShareMode
+// Set user share mode
+//  0 - texture, 1 - memory, 2 - CPU
+void spoutGL::SetShareMode(int mode)
+{
+	switch (mode) {
+
+	case 1: // Memory
+		WriteDwordToRegistry(HKEY_CURRENT_USER, "Software\\Leading Edge\\Spout", "MemoryShare", 1);
+		WriteDwordToRegistry(HKEY_CURRENT_USER, "Software\\Leading Edge\\Spout", "CPU", 0);
+		break;
+	case 2: // CPU
+		WriteDwordToRegistry(HKEY_CURRENT_USER, "Software\\Leading Edge\\Spout", "MemoryShare", 0);
+		WriteDwordToRegistry(HKEY_CURRENT_USER, "Software\\Leading Edge\\Spout", "CPU", 1);
+		break;
+	default: // 0 - Texture
+		WriteDwordToRegistry(HKEY_CURRENT_USER, "Software\\Leading Edge\\Spout", "MemoryShare", 0);
+		WriteDwordToRegistry(HKEY_CURRENT_USER, "Software\\Leading Edge\\Spout", "CPU", 0);
+		break;
+	}
+}
+
+//
+// Group: Information
+//
+
+//---------------------------------------------------------
+// Function: GetHostPath
+// The path of the host that produced the sender
+//
+// Retrieved from the description string in the sender info memory map
+bool spoutGL::GetHostPath(const char* sendername, char* hostpath, int maxchars)
+{
+	SharedTextureInfo info;
+
+	if (!sendernames.getSharedInfo(sendername, &info)) {
+		// Just quit if the key does not exist
+		SpoutLogError("spoutGL::GetHostPath - could not get sender info [%s]", sendername);
+		return false;
+	}
+
+	int n = maxchars;
+	if (n > 256) n = 256; // maximum field width in shared memory (128 wide chars)
+	strcpy_s(hostpath, n, (char*)info.description);
+
+	return true;
+}
+
+//---------------------------------------------------------
+// Function: GetVerticalSync
+// Vertical sync status
+int spoutGL::GetVerticalSync()
+{
+	// Needs OpenGL context
+	if (wglGetCurrentContext()) {
+		// needed for both sender and receiver
+		if (m_bSWAPavailable) {
+			return(wglGetSwapIntervalEXT());
+		}
+	}
+	return 0;
+}
+
+//---------------------------------------------------------
+// Function: SetVerticalSync
+// Specifies the minimum number of video frame periods per buffer swap
+//
+//   1 - wait for 1 cycle vertical refresh
+//
+//   0 - buffer swaps are not synchronized to a video frame
+//
+//  -1 - adaptive vsync
+//
+// "Adaptive" enables v-blank synchronisation when the frame rate
+// is higher than the sync rate to eliminate tearing, but disables
+// synchronisation when the frame rate drops below the sync rate
+// to minimize stuttering.
+//
+// Note that driver settings for Vertical sync "on", "off" or "adaptive"
+// over-ride this function and should be set to "Use application setting"
+// if application control is required.
+//
+// https://www.khronos.org/opengl/wiki/Swap_Interval#Adaptive_Vsync
+//
+bool spoutGL::SetVerticalSync(int interval)
+{
+	if (wglGetCurrentContext()) {
+		if (m_bSWAPavailable) {
+			if (wglSwapIntervalEXT(interval) == TRUE) {
+				return true;
+			}
+			else {
+				SpoutLogWarning("spoutGL::SetVerticalSync(%d) - Error %d\n", interval, GetLastError());
+			}
+		}
+	}
+
+	return false;
+}
+
+//---------------------------------------------------------
+// Function: GetSpoutVersion
+// Get Spout version
+//
+// Version number is retrieved from the registry at class initialization
+// Integer number 2005, 2006, 2007 etc. 0 for earlier than 2.005.
+// Set by the Spout installer for 2.005/2.006 or by SpoutSettings for 2.007 and later.
+//
+// Registry version number now replaced by std::string GetSDKversion() in SpoutUtils
+// Version number is created in constructor
+// For example : 2007 (2.007) or 2007009 (2.007.009)
+//
+int spoutGL::GetSpoutVersion()
+{
+	return m_SpoutVersion;
+}
+
+//
+// Group: Utilities
+//
+
+//---------------------------------------------------------
+// Function: CopyTexture
+//   Copy OpenGL texture with optional invert
+//   Textures must be the same size.
+//
+bool spoutGL::CopyTexture(GLuint SourceID, GLuint SourceTarget,
+	GLuint DestID, GLuint DestTarget, unsigned int width, unsigned int height,
+	bool bInvert, GLuint HostFBO)
+{
+	// Create an fbo if not already
+	if (m_fbo == 0)
+		glGenFramebuffersEXT(1, &m_fbo);
+
+	// Bind the FBO (for both, READ_FRAMEBUFFER_EXT and DRAW_FRAMEBUFFER_EXT)
+	// Empty attachments (attachments with no image attached) are complete by default.
+	glBindFramebufferEXT(GL_FRAMEBUFFER_EXT, m_fbo);
+
+	// Attach the Source texture to the color buffer in our frame buffer
+	glFramebufferTexture2DEXT(READ_FRAMEBUFFER_EXT, GL_COLOR_ATTACHMENT0_EXT, SourceTarget, SourceID, 0);
+	glReadBuffer(GL_COLOR_ATTACHMENT0_EXT);
+
+	// Attach destination texture (the texture we write into) to second attachment point
+	glFramebufferTexture2DEXT(DRAW_FRAMEBUFFER_EXT, GL_COLOR_ATTACHMENT1_EXT, DestTarget, DestID, 0);
+	glDrawBuffer(GL_COLOR_ATTACHMENT1_EXT);
+
+	GLenum status = glCheckFramebufferStatusEXT(GL_FRAMEBUFFER_EXT);
+	if (status == GL_FRAMEBUFFER_COMPLETE_EXT) {
+		if (m_bBLITavailable) {
+			// ~30 microseconds at 3480x2160
+			if (bInvert) {
+				// Copy one texture buffer to the other while flipping upside down
+				// (OpenGL and DirectX have different texture origins)
+				glBlitFramebufferEXT(0, 0, // srcX0, srcY0,
+					width, height,         // srcX1, srcY1
+					0, height,             // dstX0, dstY0,
+					width, 0,              // dstX1, dstY1,
+					GL_COLOR_BUFFER_BIT, GL_NEAREST);
+			}
+			else {
+				// Do not flip during blit
+				glBlitFramebufferEXT(0, 0, // srcX0, srcY0,
+					width, height,         // srcX1, srcY1
+					0, 0,                  // dstX0, dstY0,
+					width, height,         // dstX1, dstY1,
+					GL_COLOR_BUFFER_BIT, GL_NEAREST);
+			}
+		}
+		else {
+			// No fbo blit extension
+			// Copy from the fbo (source texture attached) to the dest texture
+			// 150-200 microseconds at 3840x2160
+			glBindTexture(DestTarget, DestID);
+			glCopyTexSubImage2D(DestTarget, 0, 0, 0, 0, 0, width, height);
+			glBindTexture(DestTarget, 0);
+		}
+	}
+	else {
+		// TODO : prevent repeats
+		PrintFBOstatus(status);
+		glDrawBuffer(GL_COLOR_ATTACHMENT0_EXT);
+		glBindFramebufferEXT(GL_FRAMEBUFFER_EXT, HostFBO);
+		return false;
+	}
+
+	// Restore default draw
+	glDrawBuffer(GL_COLOR_ATTACHMENT0_EXT);
+
+	// Unbind the color attachments
+	glFramebufferTexture2DEXT(GL_FRAMEBUFFER_EXT, GL_COLOR_ATTACHMENT1, DestTarget, 0, 0);
+	glFramebufferTexture2DEXT(GL_FRAMEBUFFER_EXT, GL_COLOR_ATTACHMENT0, SourceTarget, 0, 0);
+
+	// Restore the previous fbo - default is 0
+	glBindFramebufferEXT(GL_FRAMEBUFFER_EXT, HostFBO);
+
+	GLerror(); // Show errors
+
+	return true;
+
+} // end CopyTexture
+
+//---------------------------------------------------------
+// Function: RemovePadding
+// Remove line padding from a source image and crerate a destination image without padding
+void spoutGL::RemovePadding(const unsigned char *source, unsigned char *dest,
+	unsigned int width, unsigned int height, unsigned int stride, GLenum glFormat)
+{
+	spoutcopy.RemovePadding(source, dest, width, height, stride, glFormat);
+}
+
+
+//
+// Group : DX11 texture copy versions
+//
+// - https://github.com/DashW/Spout2
+//
+
+//---------------------------------------------------------
+// Function: ReadTexture
+// Copy the sender DirectX shared texture
+// Textures must be the same size and created with the same device
+bool spoutGL::ReadTexture(ID3D11Texture2D** texture)
+{
+	// Only for DX11 mode
+	if (!texture || !*texture || !spoutdx.GetDX11Context()) {
+		return false;
+	}
+
+	D3D11_TEXTURE2D_DESC desc = { 0 };
+	(*texture)->GetDesc(&desc);
+	if (desc.Width != m_Width || desc.Height != m_Height) {
+		return false;
+	}
+
+	// No new frame, do not block
+	if (!frame.GetNewFrame())
+		return true;
+
+	// Copy the shared texture if the sender has produced a new frame
+	if (frame.CheckTextureAccess(m_pSharedTexture)) {
+		spoutdx.GetDX11Context()->CopyResource(*texture, m_pSharedTexture);
+		// Release mutex and allow access to the texture
+		frame.AllowTextureAccess(m_pSharedTexture);
+	}
+
+	return true;
+
+} // end ReadTexture
+
+
+//---------------------------------------------------------
+// Function: WriteTexture
+// Copy to the sender DirectX shared texture
+// Textures must be the same size and created with the same device
+bool spoutGL::WriteTexture(ID3D11Texture2D** texture)
+{
+	// Only for DX11 mode
+	if (!texture || !spoutdx.GetDX11Context()) {
+		SpoutLogWarning("spoutGL::WriteTexture(ID3D11Texture2D** texture) failed");
+		if (!texture)
+			SpoutLogWarning("    ID3D11Texture2D** NULL");
+		if (!spoutdx.GetDX11Context())
+			SpoutLogVerbose("    pImmediateContext NULL");
+		return false;
+	}
+
+	bool bRet = false;
+	D3D11_TEXTURE2D_DESC desc = { 0 };
+
+	(*texture)->GetDesc(&desc);
+	if (desc.Width != m_Width || desc.Height != m_Height) {
+		SpoutLogWarning("spoutGL::WriteTexture(ID3D11Texture2D** texture) sizes do not match");
+		SpoutLogWarning("    texture (%dx%d) : sender (%dx%d)", desc.Width, desc.Height, m_Width, m_Height);
+		return false;
+	}
+
+	// Wait for access to the shared texture
+	if (frame.CheckTextureAccess(m_pSharedTexture)) {
+		spoutdx.GetDX11Context()->CopyResource(m_pSharedTexture, *texture);
+		// Flush after update of the shared texture on this device
+		spoutdx.GetDX11Context()->Flush();
+		// Increment the sender frame counter
+		frame.SetNewFrame();
+		// Release mutex and allow access to the texture
+		frame.AllowTextureAccess(m_pSharedTexture);
+		bRet = true;
+	}
+
+	return bRet;
+}
+
+
+//---------------------------------------------------------
+// Function: WriteTextureReadback
+// Copy a DX11 texture to the DX11 shared texture
+// Copy the linked OpenGL texture back to an OpenGL texture
+// Textures must be the same size and created with the same device
+bool spoutGL::WriteTextureReadback(ID3D11Texture2D** texture,
+	GLuint TextureID, GLuint TextureTarget,
+	unsigned int width, unsigned int height,
+	bool bInvert, GLuint HostFBO)
+{
+	// Only for DX11 mode
+	if (!texture || !spoutdx.GetDX11Context()) {
+		SpoutLogWarning("spoutGL::WriteTextureReadback(ID3D11Texture2D** texture) failed");
+		if (!texture)
+			SpoutLogWarning("    ID3D11Texture2D** NULL");
+		if (!spoutdx.GetDX11Context())
+			SpoutLogVerbose("    pImmediateContext NULL");
+		return false;
+	}
+
+	if (!m_hInteropDevice || !m_hInteropObject) {
+		SpoutLogWarning("spoutGL::WriteTextureReadback() no GL/DX interop\n	m_hInteropObject = 0x%7.7X - m_hInteropDevice = 0x%7.7X", PtrToUint(m_hInteropDevice), PtrToUint(m_hInteropObject));
+		return false;
+	}
+
+	bool bRet = false;
+	D3D11_TEXTURE2D_DESC desc = { 0 };
+
+	(*texture)->GetDesc(&desc);
+	if (desc.Width != m_Width || desc.Height != m_Height) {
+		SpoutLogWarning("spoutGL::WriteTextureReadback(ID3D11Texture2D** texture) sizes do not match");
+		SpoutLogWarning("    texture (%dx%d) : sender (%dx%d)", desc.Width, desc.Height, m_Width, m_Height);
+		return false;
+	}
+
+	// Wait for access to the shared texture
+	if (frame.CheckTextureAccess(m_pSharedTexture)) {
+		bRet = true;
+		
+		// Copy the DirectX texture to the shared texture
+		spoutdx.GetDX11Context()->CopyResource(m_pSharedTexture, *texture);
+		// Flush after update of the shared texture on this device
+		spoutdx.GetDX11Context()->Flush();
+
+		// Copy the linked OpenGL texture back to the user texture
+		if (width != m_Width || height != m_Height) {
+			SpoutLogWarning("spoutGL::WriteTextureReadback(ID3D11Texture2D** texture) sizes do not match");
+			SpoutLogWarning("    OpenGL texture (%dx%d) : sender (%dx%d)", desc.Width, desc.Height, m_Width, m_Height);
+			bRet = false;
+		}
+		else if (LockInteropObject(m_hInteropDevice, &m_hInteropObject) == S_OK) {
+			// Copy the shared texture (m_glTexture) to the user texture
+			bRet = CopyTexture(m_glTexture, GL_TEXTURE_2D, TextureID, TextureTarget, width, height, bInvert, HostFBO);
+			UnlockInteropObject(m_hInteropDevice, &m_hInteropObject);
+			if (!bRet)
+				SpoutLogWarning("spoutGL::WriteTextureReadback(ID3D11Texture2D** texture) readback failed");
+		}
+
+		// Increment the sender frame counter
+		frame.SetNewFrame();
+		// Release mutex and allow access to the texture
+		frame.AllowTextureAccess(m_pSharedTexture);
+	}
+
+	return bRet;
+}

--- a/libs/SpoutSDK/src/SpoutGL.h
+++ b/libs/SpoutSDK/src/SpoutGL.h
@@ -1,0 +1,443 @@
+/*
+
+	SpoutGL.h
+	
+	Base class for OpenGL SpoutSDK
+	See also Sender and Receiver wrapper classes.
+
+	Copyright (c) 2021-2024, Lynn Jarvis. All rights reserved.
+
+	Redistribution and use in source and binary forms, with or without modification, 
+	are permitted provided that the following conditions are met:
+
+		1. Redistributions of source code must retain the above copyright notice, 
+		   this list of conditions and the following disclaimer.
+
+		2. Redistributions in binary form must reproduce the above copyright notice, 
+		   this list of conditions and the following disclaimer in the documentation 
+		   and/or other materials provided with the distribution.
+
+	THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"	AND ANY 
+	EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES 
+	OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE	ARE DISCLAIMED. 
+	IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
+	INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, 
+	PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+	INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+	LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+	OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ 
+*/
+#pragma once
+
+#ifndef __spoutGL__
+#define __spoutGL__
+
+// Change the path as required
+#include "SpoutGLextensions.h" // include first so that gl.h is not included first if Glew is used
+#include "SpoutCommon.h" // for dll build and utilities
+#include "SpoutSenderNames.h" // for sender creation and update
+#include "SpoutDirectX.h" // for DX11 shared textures
+#include "SpoutFrameCount.h" // for mutex lock and new frame signal
+#include "SpoutCopy.h" // for pixel copy
+
+#include <direct.h> // for _getcwd
+#include <TlHelp32.h> // for PROCESSENTRY32
+#include <tchar.h> // for _tcsicmp
+#include <algorithm> // for string character remove
+
+#pragma warning(disable : 26485)
+
+// Used throughout
+using namespace spoututils;
+
+
+class SPOUT_DLLEXP spoutGL {
+
+	public:
+
+	spoutGL();
+    virtual ~spoutGL();
+
+	//
+	// OpenGL shared texture access
+	//
+
+	// Bind OpenGL shared texture
+	bool BindSharedTexture();
+	// Un-bind OpenGL shared texture
+	bool UnBindSharedTexture();
+	// OpenGL shared texture ID
+	GLuint GetSharedTextureID();
+
+	//
+	// Graphics compatibility
+	//
+
+	// Get user auto GPU/CPU share
+	bool GetAutoShare();
+	// Set application auto GPU/CPU share
+	void SetAutoShare(bool bAuto = true);
+	// Get user CPU share
+	bool GetCPUshare();
+	// Set application CPU share
+	// (re-test GL/DX compatibility if set to false)
+	void SetCPUshare(bool bCPU = true);
+	// OpenGL texture share compatibility
+	bool IsGLDXready();
+
+	//
+	// User settings recorded in the registry by "SpoutSettings"
+	//
+	
+	// Get user buffering mode
+	bool GetBufferMode();
+	// Set application buffering mode
+	void SetBufferMode(bool bActive = true);
+	// Get user number of pixel buffers
+	int GetBuffers();
+	// Set application number of pixel buffers
+	void SetBuffers(int nBuffers);
+	// Get user Maximum senders allowed
+	int GetMaxSenders();
+	// Set user Maximum senders allowed
+	void SetMaxSenders(int maxSenders);
+	
+	//
+	// 2.006 compatibility
+	//
+
+	// Get user DX9 mode
+	bool GetDX9();
+	// Set user DX9 mode
+	bool SetDX9(bool bDX9 = true);
+	// Get user memory share mode
+	bool GetMemoryShareMode();
+	// Set user memory share mode
+	bool SetMemoryShareMode(bool bMem = true);
+	// Get user CPU mode
+	bool GetCPUmode();
+	// Set user CPU mode
+	bool SetCPUmode(bool bCPU);
+	// Get user share mode
+	//  0 - texture, 1 - memory, 2 - CPU
+	int GetShareMode();
+	// Set user share mode
+	//  0 - texture, 1 - memory, 2 - CPU
+	void SetShareMode(int mode);
+
+	//
+	// Information
+	//
+
+	// The path of the host that produced the sender
+	bool GetHostPath(const char *sendername, char *hostpath, int maxchars);
+	// Vertical sync status
+	int GetVerticalSync();
+	// Lock to monitor vertical sync
+	bool SetVerticalSync(int interval = 1);
+	// Get Spout version
+	int GetSpoutVersion();
+
+	//
+	// Utility
+	//
+	
+	// Copy OpenGL texture with optional invert
+	bool CopyTexture(GLuint SourceID, GLuint SourceTarget, GLuint DestID, GLuint DestTarget,
+		unsigned int width, unsigned int height, bool bInvert = false, GLuint HostFBO = 0);
+	// Correct for image stride
+	void RemovePadding(const unsigned char *source, unsigned char *dest,
+		unsigned int width, unsigned int height, unsigned int stride, GLenum glFormat = GL_RGBA);
+	// OpenGL error reprting
+	bool GLerror();
+
+	// DX11 texture read
+	//  o Copy from the shared DX11 texture to a DX11 texture
+	bool ReadTexture(ID3D11Texture2D** texture);
+	// DX11 texture write
+	//  o Copy a DX11 texture to the shared DX11 texture
+	bool WriteTexture(ID3D11Texture2D** texture);
+	// DX11 texture write with readback to OpenGL texture
+	//   o Copy a DX11 texture to the DX11 shared texture
+	//   o Copy the linked OpenGL texture back to an OpenGL texture
+	bool WriteTextureReadback(ID3D11Texture2D** texture, GLuint TextureID, GLuint TextureTarget,
+		unsigned int width, unsigned int height, bool bInvert, GLuint HostFBO = 0);
+
+	// Initialize OpenGL and DX11
+	//     o Load extensions and check for availability and function
+	//     o Open DirectX and check for availability
+	//     o Compatibility test for use or GL/DX interop
+	//     o Optionally re-test compatibility even if already initialized
+	bool OpenSpout(bool bRetest = false);
+	// Initialize DirectX
+	bool OpenDirectX();
+	// Close DirectX and free resources
+	void CloseDirectX();
+
+	//
+	// Formats
+	//
+
+	// Get sender DX11 shared texture format
+	DXGI_FORMAT GetDX11format();
+	// Set sender DX11 shared texture format
+	void SetDX11format(DXGI_FORMAT textureformat);
+	// Return OpenGL compatible DX11 format
+	DXGI_FORMAT DX11format(GLint glformat);
+	// Return DX11 compatible OpenGL format
+	GLint GLDXformat(DXGI_FORMAT textureformat = DXGI_FORMAT_UNKNOWN);
+	// Return OpenGL texture internal format
+	GLint GLformat(GLuint TextureID, GLuint TextureTarget);
+	// Return OpenGL texture format description
+	std::string GLformatName(GLint glformat = 0);
+
+	// Create an OpenGL window and context for situations where there is none.
+	//   Not used if applications already have an OpenGL context.
+	//   Always call CloseOpenGL afterwards.
+	bool CreateOpenGL();
+	// Close OpenGL window
+	bool CloseOpenGL();
+	// Class initialization status
+	bool IsSpoutInitialized();
+	// Perform tests for GL/DX interop availability and compatibility
+	bool GLDXready();
+	// Set host path to sender shared memory
+	bool SetHostPath(const char *sendername);
+	// Set sender PartnerID field with CPU sharing method and GL/DX compatibility
+	bool SetSenderID(const char *sendername, bool bCPU, bool bGLDX);
+	
+	//
+	// 2.006 compatibility
+	//
+
+	bool OpenDirectX11(ID3D11Device* pDevice = nullptr);
+	ID3D11Device* GetDX11Device();
+	ID3D11DeviceContext* GetDX11Context();
+	void CleanupDirectX();
+	void CleanupDX11();
+	bool CleanupInterop();
+
+	//
+	// OpenGL extensions
+	//
+
+	bool LoadGLextensions();
+	bool IsGLDXavailable(); // GL/DX interop extensions supported
+	bool IsBLITavailable(); // fbo blit extensions available
+	bool IsSWAPavailable(); // swap extensions available
+	bool IsBGRAavailable(); // bgra extensions available
+	bool IsCOPYavailable(); // copy extensions available
+	bool IsPBOavailable();  // pbo extensions supported
+	bool IsCONTEXTavailable(); // Context extension supported
+
+	//
+	// Legacy OpenGL functions
+	//
+
+	// See _SpoutCommon.h_ #define legacyOpenGL
+#ifdef legacyOpenGL
+	void SaveOpenGLstate(unsigned int width, unsigned int height, bool bFitWindow = true);
+	void RestoreOpenGLstate();
+#endif
+
+	//
+	// Public for special use
+	//
+
+	// Link a shared DirectX texture to an OpenGL texture
+	HANDLE LinkGLDXtextures(void* pDXdevice, void* pSharedTexture, GLuint glTextureID);
+	// Return a handle to the the DX/GL interop device
+	HANDLE GetInteropDevice();
+	// Return a handle to the the DX/GL interop ojject
+	HANDLE GetInteropObject();
+	// Pointer to the shared DirectX texture
+	ID3D11Texture2D* GetDXsharedTexture();
+	// Create OpenGL texture
+	void InitTexture(GLuint& texID, GLenum GLformat, unsigned int width, unsigned int height);
+	// Copy OpenGL to shared DirectX 11 texture via CPU
+	bool WriteDX11texture(GLuint TextureID, GLuint TextureTarget, unsigned int width, unsigned int height, bool bInvert, GLuint HostFBO);
+	// Copy from shared DX11 texture to OpenGL via CPU
+	bool ReadDX11texture(GLuint TextureID, GLuint TextureTarget, unsigned int width, unsigned int height, bool bInvert, GLuint HostFBO);
+	// Read pixels from an OpenGL texture using pbo
+	bool UnloadTexturePixels(GLuint TextureID, GLuint TextureTarget,
+		unsigned int width, unsigned int height, unsigned int pitch,
+		unsigned char* data, GLenum glFormat = GL_RGBA,
+		bool bInvert = false, GLuint HostFBO = 0);
+	// Load pixels to an OpenGL texture using pbo
+	bool LoadTexturePixels(GLuint TextureID, GLuint TextureTarget,
+		unsigned int width, unsigned int height, 
+		const unsigned char* data, int GLformat = GL_RGBA,
+		bool bInvert = false);
+	// Read RGB or RGBA pixels from an OpenGL texture with format
+	bool ReadTexturePixels(GLuint TextureID, GLuint TextureTarget,
+		unsigned int width, unsigned int height, void* dest,
+		GLenum GLformat, int nChannels);
+
+
+	//
+	// Data sharing
+	//
+
+	// Write data to shared memory
+	bool WriteMemoryBuffer(const char *name, const char* data, int length);
+	// Read data from shared memory
+	int ReadMemoryBuffer(const char* name, char* data, int maxlength);
+	// Create a shared memory buffer
+	bool CreateMemoryBuffer(const char *name, int length);
+	// Delete a shared memory buffer
+	bool DeleteMemoryBuffer();
+	// Get the number of bytes available for data transfer
+	int GetMemoryBufferSize(const char *name);
+
+	//
+	// For external access
+	//
+
+	// DirectX 11 texture sharing
+	spoutDirectX spoutdx;
+	// Pixel buffer copying
+	spoutCopy spoutcopy;
+	// Spout sender management
+	spoutSenderNames sendernames;
+	// Frame counting management
+	spoutFrameCount frame;
+
+protected :
+	
+	// For 2.006(receive only) / WriteMemoryBuffer / ReadMemoryBuffer
+	SpoutSharedMemory memoryshare;
+
+	// GL/DX functions
+	bool CreateInterop(unsigned int width, unsigned int height, DWORD dwFormat, bool bReceive);
+	HRESULT LockInteropObject(HANDLE hDevice, HANDLE *hObject);
+	HRESULT UnlockInteropObject(HANDLE hDevice, HANDLE *hObject);
+	void CleanupGL(); // Free OpenGL resources
+
+	// OpenGL texture create
+	void CheckOpenGLTexture(GLuint &texID, GLenum GLformat, unsigned int width, unsigned int height);
+
+	// OpenGL texture copy
+	bool WriteGLDXtexture(GLuint TextureID, GLuint TextureTarget, unsigned int width, unsigned int height, bool bInvert = true, GLuint HostFBO = 0);
+	bool ReadGLDXtexture(GLuint TextureID, GLuint TextureTarget, unsigned int width, unsigned int height, bool bInvert = false, GLuint HostFBO = 0);
+	bool SetSharedTextureData(GLuint TextureID, GLuint TextureTarget, unsigned int width, unsigned int height, bool bInvert, GLuint HostFBO);
+	
+	// OpenGL pixel copy
+	bool WriteGLDXpixels(const unsigned char* pixels, unsigned int width, unsigned int height, GLenum glFormat = GL_RGBA, bool bInvert = false, GLuint HostFBO = 0);
+	bool ReadGLDXpixels(unsigned char* pixels, unsigned int width, unsigned int height, GLenum glFormat = GL_RGBA, bool bInvert = false, GLuint HostFBO = 0);
+	
+	// PBOs for OpenGL pixel copy
+	GLuint m_pbo[4];
+	int PboIndex;
+	int NextPboIndex;
+	int m_nBuffers;
+	
+	// OpenGL <-> DX11
+	// WriteDX11texture - public
+	// ReadDX11texture  - public
+	bool ReadTextureData(GLuint SourceID, GLuint SourceTarget, unsigned int width, unsigned int height, unsigned int pitch, unsigned char* dest, GLenum GLformat, bool bInvert, GLuint HostFBO);
+	
+	// Pixels <-> DX11
+	bool WriteDX11pixels(const unsigned char* pixels, unsigned int width, unsigned int height, GLenum glFormat = GL_RGBA, bool bInvert = false);
+	bool ReadDX11pixels(unsigned char * pixels, unsigned int width, unsigned int height, GLenum glFormat = GL_RGBA, bool bInvert = false);
+	bool WritePixelData(const unsigned char* pixels, ID3D11Texture2D* pStagingTexture, unsigned int width, unsigned int height, GLenum glFormat, bool bInvert);
+	bool ReadPixelData(ID3D11Texture2D* pStagingTexture, unsigned char* pixels, unsigned int width, unsigned int height, GLenum glFormat, bool bInvert);
+
+	// Staging textures for DX11 CPU copy
+	ID3D11Texture2D* m_pStaging[2];
+	int m_Index;
+	int m_NextIndex;
+	bool CheckStagingTextures(unsigned int width, unsigned int height, int nTextures);
+
+	// 2.006 shared memory
+	bool ReadMemoryTexture(const char* sendername, GLuint TexID, GLuint TextureTarget, unsigned int width, unsigned int height, bool bInvert = false, GLuint HostFBO = 0);
+	bool ReadMemoryPixels(const char* sendername, unsigned char* pixels, unsigned int width, unsigned int height, GLenum glFormat = GL_RGBA, bool bInvert = false);
+	bool WriteMemoryPixels(const char *sendername, const unsigned char* pixels, unsigned int width, unsigned int height, GLenum glFormat = GL_RGBA, bool bInvert = false);
+
+	// Utility
+	bool OpenDeviceKey(const char* key, int maxsize, char* description, char* version);
+	void trim(char* s);
+
+	// Errors
+	void DoDiagnostics(const char *error);
+	void PrintFBOstatus(GLenum status);
+
+	//
+	// Class globals
+	//
+
+	// Sender/Receiver
+	char m_SenderName[256];
+	char m_SenderNameSetup[256];
+	unsigned int m_Width;
+	unsigned int m_Height;
+
+	// Utility
+	GLuint m_fbo; // Fbo used for OpenGL functions
+	GLuint m_TexID; // Class texture used for invert copy
+	unsigned int m_TexWidth;
+	unsigned int m_TexHeight;
+	DWORD m_TexFormat;
+
+	// Shared texture
+	GLuint m_glTexture; // OpenGL shared texture
+	ID3D11Texture2D* m_pSharedTexture; // DirectX shared texture
+	HANDLE m_dxShareHandle; // DirectX shared texture handle
+	DXGI_FORMAT m_DX11format; // DirectX 11 shared texture format
+	DWORD m_dwFormat; // DWORD texture format used throughout
+
+	// GL/DX interop
+	HANDLE m_hInteropDevice; // Handle to the DX/GL interop device
+	HANDLE m_hInteropObject; // Handle to the DX/GL interop object (the shared texture)
+	bool m_bInteropFailed = false; // Interop failure flag to avoid repeats
+
+	// General
+	HWND m_hWnd; // OpenGL window
+	int m_SpoutVersion; // Spout version
+
+	// For CreateOpenGL and CloseOpenGL
+	HDC m_hdc;
+	HWND m_hwndButton;
+	HGLRC m_hRc;
+
+	// Status flags
+	bool m_bConnected;
+	bool m_bUpdated;
+	bool m_bInitialized;
+	bool m_bMirror;  // Mirror image (used for SpoutCam)
+	bool m_bSwapRB;  // RGB <> BGR (used for SpoutCam)
+	bool m_bGLDXdone; // Compatibility test done
+
+	// Sharing modes
+	bool m_bAuto;         // Auto share mode - user set
+	bool m_bCPU;          // Global CPU mode - user set
+	bool m_bUseGLDX;      // Hardware GL/DX interop compatibility
+	bool m_bTextureShare; // Using texture sharing methods
+	bool m_bCPUshare;     // Using CPU sharing methods
+	bool m_bMemoryShare;  // Using 2.006 memoryshare methods
+	
+	// Sender sharing modes
+	bool m_bSenderCPU;    // Sender using CPU sharing methods
+	bool m_bSenderGLDX;   // Sender hardware GL/DX compatibility
+
+	// For SpoutPanel sender selection
+	bool m_bSpoutPanelOpened;
+	bool m_bSpoutPanelActive;
+	SHELLEXECUTEINFOA m_ShExecInfo;
+
+	// OpenGL extensions
+	unsigned int m_caps;
+	bool m_bGLDXavailable;
+	bool m_bFBOavailable;
+	bool m_bBLITavailable;
+	bool m_bPBOavailable;
+	bool m_bSWAPavailable;
+	bool m_bBGRAavailable;
+	bool m_bCOPYavailable;
+	bool m_bCONTEXTavailable;
+	bool m_bExtensionsLoaded;
+
+
+};
+
+#endif


### PR DESCRIPTION
It appears some library files may have been missed, causing the build to fail.
This PR updates the ignore settings and adds the (likely) missing files so the project can build successfully again.